### PR TITLE
chore: Lower SDK constraint

### DIFF
--- a/hrana/pubspec.yaml
+++ b/hrana/pubspec.yaml
@@ -10,7 +10,7 @@ topics:
   - hrana
 
 environment:
-  sdk: ^3.4.4
+  sdk: ^3.4.0
 
 dependencies:
   fixnum: ^1.1.0


### PR DESCRIPTION
To match `drift_hrana` and since Flutter stable is only 3.4.3 at the moment.

Awesome work btw!