### PR TITLE
feat(hrana): Support HTTP protocol

### DIFF
--- a/hrana/lib/src/database.dart
+++ b/hrana/lib/src/database.dart
@@ -1,9 +1,9 @@
-import 'package:hrana/src/rpc_http_client.dart';
 import 'package:sqlite3/common.dart';
 
 import 'exception.dart';
 import 'protocol.pb.dart' as proto;
 import 'rpc_client.dart';
+import 'rpc_http_client.dart';
 import 'rpc_ws_client.dart';
 
 /// A connection to a remote sqlite3 database following the hrana protocol.

--- a/hrana/lib/src/database.dart
+++ b/hrana/lib/src/database.dart
@@ -1,8 +1,10 @@
+import 'package:hrana/src/rpc_http_client.dart';
 import 'package:sqlite3/common.dart';
 
 import 'exception.dart';
-import 'rpc_client.dart';
 import 'protocol.pb.dart' as proto;
+import 'rpc_client.dart';
+import 'rpc_ws_client.dart';
 
 /// A connection to a remote sqlite3 database following the hrana protocol.
 ///
@@ -19,12 +21,31 @@ final class Database {
 
   Database._(this._client, this._stream);
 
-  /// Connects to a hrana server under the given websocket [uri].
+  /// Connects to a hrana server under the given [uri].
   ///
-  /// The `scheme` of [uri] should be either `ws` or `wss`.
+  /// The `scheme` of [uri] should be one of: `libsql`, `http`, `https`, `ws`
+  /// or `wss`.
+  ///
   /// Optionally, a [jwtToken] can be passed for authentication purposes.
   static Future<Database> connect(Uri uri, {String? jwtToken}) async {
-    final client = await HranaClient.connect(uri, jwtToken: jwtToken);
+    if (uri.scheme == 'libsql') {
+      uri = uri.replace(scheme: 'https');
+    }
+    final client = switch (uri.scheme) {
+      'ws' || 'wss' => await HranaWebsocketClient.connect(
+          uri,
+          jwtToken: jwtToken,
+        ),
+      'http' || 'https' => await HranaHttpClient.connect(
+          uri,
+          jwtToken: jwtToken,
+        ),
+      _ => throw ArgumentError.value(
+          uri,
+          'uri',
+          'Scheme must be one of: "libsql", "http", "https", "ws" or "wss"',
+        ),
+    };
     final stream = await client.openStream();
 
     return Database._(client, stream);
@@ -93,8 +114,8 @@ final class Database {
   /// [StoredSql.execute].
   /// After using it, it must be closed with [StoredSql.close].
   Future<StoredSql> storeSql(String sql) async {
-    final id = await _client.storeSql(sql);
-    return StoredSql._(id, this);
+    final id = await _client.storeSql(_stream, sql);
+    return StoredSql._(_stream, id, this);
   }
 
   /// Collects statements to run in a batch (via [BatchBuilder]) and then runs
@@ -146,11 +167,12 @@ final class Database {
 /// After the [StoredSql] instance is no longer used, it must be [close]d to
 /// free up resources on the server.
 final class StoredSql {
+  final SqlStreamId _streamId;
   final SqlTextId _id;
   final Database _database;
   bool _closed = false;
 
-  StoredSql._(this._id, this._database);
+  StoredSql._(this._streamId, this._id, this._database);
 
   void _checkNotClosed() {
     if (_closed) {
@@ -194,7 +216,7 @@ final class StoredSql {
   Future<void> close() async {
     if (!_closed) {
       _closed = true;
-      await _database._client.closeSql(_id);
+      await _database._client.closeSql(_streamId, _id);
     }
   }
 }
@@ -292,7 +314,7 @@ final class BatchResult {
 
   StatementResult? _rawResult(BatchRequest request) {
     if (_result.stepErrors[request._id] case proto.Error e) {
-      throw HranaClient.createError(e);
+      throw ServerException.fromProto(e);
     }
     if (_result.stepResults[request._id] case proto.StmtResult r) {
       return StatementResult.fromProto(r);

--- a/hrana/lib/src/exception.dart
+++ b/hrana/lib/src/exception.dart
@@ -1,3 +1,5 @@
+import 'protocol.pb.dart' as proto;
+
 /// Superclass for all exceptions thrown by `package:hrana`.
 ///
 /// Note that, for invalid usage, subclasses of [Error] may be thrown as well.
@@ -21,6 +23,10 @@ final class ServerException implements HranaException {
   final String? code;
 
   ServerException({required this.message, required this.code});
+
+  factory ServerException.fromProto(proto.Error error) {
+    return ServerException(message: error.message, code: error.code);
+  }
 
   @override
   String toString() {

--- a/hrana/lib/src/protocol.pb.dart
+++ b/hrana/lib/src/protocol.pb.dart
@@ -282,6 +282,10 @@ class StmtResult extends $pb.GeneratedMessage {
     $core.Iterable<Row>? rows,
     $fixnum.Int64? affectedRowCount,
     $fixnum.Int64? lastInsertRowid,
+    $fixnum.Int64? replicationIndex,
+    $fixnum.Int64? rowsRead,
+    $fixnum.Int64? rowsWritten,
+    $core.double? queryDurationMs,
   }) {
     final $result = create();
     if (cols != null) {
@@ -295,6 +299,18 @@ class StmtResult extends $pb.GeneratedMessage {
     }
     if (lastInsertRowid != null) {
       $result.lastInsertRowid = lastInsertRowid;
+    }
+    if (replicationIndex != null) {
+      $result.replicationIndex = replicationIndex;
+    }
+    if (rowsRead != null) {
+      $result.rowsRead = rowsRead;
+    }
+    if (rowsWritten != null) {
+      $result.rowsWritten = rowsWritten;
+    }
+    if (queryDurationMs != null) {
+      $result.queryDurationMs = queryDurationMs;
     }
     return $result;
   }
@@ -319,6 +335,17 @@ class StmtResult extends $pb.GeneratedMessage {
     ..a<$fixnum.Int64>(
         4, _omitFieldNames ? '' : 'lastInsertRowid', $pb.PbFieldType.OS6,
         defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(
+        5, _omitFieldNames ? '' : 'replicationIndex', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(
+        6, _omitFieldNames ? '' : 'rowsRead', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(
+        7, _omitFieldNames ? '' : 'rowsWritten', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.double>(
+        8, _omitFieldNames ? '' : 'queryDurationMs', $pb.PbFieldType.OD)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('Using this can add significant overhead to your binary. '
@@ -371,6 +398,54 @@ class StmtResult extends $pb.GeneratedMessage {
   $core.bool hasLastInsertRowid() => $_has(3);
   @$pb.TagNumber(4)
   void clearLastInsertRowid() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $fixnum.Int64 get replicationIndex => $_getI64(4);
+  @$pb.TagNumber(5)
+  set replicationIndex($fixnum.Int64 v) {
+    $_setInt64(4, v);
+  }
+
+  @$pb.TagNumber(5)
+  $core.bool hasReplicationIndex() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearReplicationIndex() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get rowsRead => $_getI64(5);
+  @$pb.TagNumber(6)
+  set rowsRead($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
+  @$pb.TagNumber(6)
+  $core.bool hasRowsRead() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearRowsRead() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $fixnum.Int64 get rowsWritten => $_getI64(6);
+  @$pb.TagNumber(7)
+  set rowsWritten($fixnum.Int64 v) {
+    $_setInt64(6, v);
+  }
+
+  @$pb.TagNumber(7)
+  $core.bool hasRowsWritten() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearRowsWritten() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.double get queryDurationMs => $_getN(7);
+  @$pb.TagNumber(8)
+  set queryDurationMs($core.double v) {
+    $_setDouble(7, v);
+  }
+
+  @$pb.TagNumber(8)
+  $core.bool hasQueryDurationMs() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearQueryDurationMs() => clearField(8);
 }
 
 class Col extends $pb.GeneratedMessage {
@@ -4364,6 +4439,998 @@ class GetAutocommitResp extends $pb.GeneratedMessage {
   $core.bool hasIsAutocommit() => $_has(0);
   @$pb.TagNumber(1)
   void clearIsAutocommit() => clearField(1);
+}
+
+class PipelineReq extends $pb.GeneratedMessage {
+  factory PipelineReq({
+    $core.String? baton,
+    $core.Iterable<StreamRequest>? requests,
+  }) {
+    final $result = create();
+    if (baton != null) {
+      $result.baton = baton;
+    }
+    if (requests != null) {
+      $result.requests.addAll(requests);
+    }
+    return $result;
+  }
+  PipelineReq._() : super();
+  factory PipelineReq.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PipelineReq.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PipelineReq',
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'baton')
+    ..pc<StreamRequest>(
+        2, _omitFieldNames ? '' : 'requests', $pb.PbFieldType.PM,
+        subBuilder: StreamRequest.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  PipelineReq clone() => PipelineReq()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  PipelineReq copyWith(void Function(PipelineReq) updates) =>
+      super.copyWith((message) => updates(message as PipelineReq))
+          as PipelineReq;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PipelineReq create() => PipelineReq._();
+  PipelineReq createEmptyInstance() => create();
+  static $pb.PbList<PipelineReq> createRepeated() => $pb.PbList<PipelineReq>();
+  @$core.pragma('dart2js:noInline')
+  static PipelineReq getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<PipelineReq>(create);
+  static PipelineReq? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get baton => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set baton($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasBaton() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearBaton() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<StreamRequest> get requests => $_getList(1);
+}
+
+enum StreamRequest_Request {
+  close,
+  execute,
+  batch,
+  sequence,
+  describe,
+  storeSql,
+  closeSql,
+  getAutocommit,
+  notSet
+}
+
+class StreamRequest extends $pb.GeneratedMessage {
+  factory StreamRequest({
+    CloseStreamReq? close,
+    ExecuteStreamReq? execute,
+    BatchStreamReq? batch,
+    SequenceStreamReq? sequence,
+    DescribeStreamReq? describe,
+    StoreSqlReq? storeSql,
+    CloseSqlReq? closeSql,
+    GetAutocommitReq? getAutocommit,
+  }) {
+    final $result = create();
+    if (close != null) {
+      $result.close = close;
+    }
+    if (execute != null) {
+      $result.execute = execute;
+    }
+    if (batch != null) {
+      $result.batch = batch;
+    }
+    if (sequence != null) {
+      $result.sequence = sequence;
+    }
+    if (describe != null) {
+      $result.describe = describe;
+    }
+    if (storeSql != null) {
+      $result.storeSql = storeSql;
+    }
+    if (closeSql != null) {
+      $result.closeSql = closeSql;
+    }
+    if (getAutocommit != null) {
+      $result.getAutocommit = getAutocommit;
+    }
+    return $result;
+  }
+  StreamRequest._() : super();
+  factory StreamRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StreamRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static const $core.Map<$core.int, StreamRequest_Request>
+      _StreamRequest_RequestByTag = {
+    1: StreamRequest_Request.close,
+    2: StreamRequest_Request.execute,
+    3: StreamRequest_Request.batch,
+    4: StreamRequest_Request.sequence,
+    5: StreamRequest_Request.describe,
+    6: StreamRequest_Request.storeSql,
+    7: StreamRequest_Request.closeSql,
+    8: StreamRequest_Request.getAutocommit,
+    0: StreamRequest_Request.notSet
+  };
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StreamRequest',
+      createEmptyInstance: create)
+    ..oo(0, [1, 2, 3, 4, 5, 6, 7, 8])
+    ..aOM<CloseStreamReq>(1, _omitFieldNames ? '' : 'close',
+        subBuilder: CloseStreamReq.create)
+    ..aOM<ExecuteStreamReq>(2, _omitFieldNames ? '' : 'execute',
+        subBuilder: ExecuteStreamReq.create)
+    ..aOM<BatchStreamReq>(3, _omitFieldNames ? '' : 'batch',
+        subBuilder: BatchStreamReq.create)
+    ..aOM<SequenceStreamReq>(4, _omitFieldNames ? '' : 'sequence',
+        subBuilder: SequenceStreamReq.create)
+    ..aOM<DescribeStreamReq>(5, _omitFieldNames ? '' : 'describe',
+        subBuilder: DescribeStreamReq.create)
+    ..aOM<StoreSqlReq>(6, _omitFieldNames ? '' : 'storeSql',
+        subBuilder: StoreSqlReq.create)
+    ..aOM<CloseSqlReq>(7, _omitFieldNames ? '' : 'closeSql',
+        subBuilder: CloseSqlReq.create)
+    ..aOM<GetAutocommitReq>(8, _omitFieldNames ? '' : 'getAutocommit',
+        subBuilder: GetAutocommitReq.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  StreamRequest clone() => StreamRequest()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StreamRequest copyWith(void Function(StreamRequest) updates) =>
+      super.copyWith((message) => updates(message as StreamRequest))
+          as StreamRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StreamRequest create() => StreamRequest._();
+  StreamRequest createEmptyInstance() => create();
+  static $pb.PbList<StreamRequest> createRepeated() =>
+      $pb.PbList<StreamRequest>();
+  @$core.pragma('dart2js:noInline')
+  static StreamRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<StreamRequest>(create);
+  static StreamRequest? _defaultInstance;
+
+  StreamRequest_Request whichRequest() =>
+      _StreamRequest_RequestByTag[$_whichOneof(0)]!;
+  void clearRequest() => clearField($_whichOneof(0));
+
+  @$pb.TagNumber(1)
+  CloseStreamReq get close => $_getN(0);
+  @$pb.TagNumber(1)
+  set close(CloseStreamReq v) {
+    setField(1, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasClose() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearClose() => clearField(1);
+  @$pb.TagNumber(1)
+  CloseStreamReq ensureClose() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  ExecuteStreamReq get execute => $_getN(1);
+  @$pb.TagNumber(2)
+  set execute(ExecuteStreamReq v) {
+    setField(2, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasExecute() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearExecute() => clearField(2);
+  @$pb.TagNumber(2)
+  ExecuteStreamReq ensureExecute() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  BatchStreamReq get batch => $_getN(2);
+  @$pb.TagNumber(3)
+  set batch(BatchStreamReq v) {
+    setField(3, v);
+  }
+
+  @$pb.TagNumber(3)
+  $core.bool hasBatch() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearBatch() => clearField(3);
+  @$pb.TagNumber(3)
+  BatchStreamReq ensureBatch() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  SequenceStreamReq get sequence => $_getN(3);
+  @$pb.TagNumber(4)
+  set sequence(SequenceStreamReq v) {
+    setField(4, v);
+  }
+
+  @$pb.TagNumber(4)
+  $core.bool hasSequence() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearSequence() => clearField(4);
+  @$pb.TagNumber(4)
+  SequenceStreamReq ensureSequence() => $_ensure(3);
+
+  @$pb.TagNumber(5)
+  DescribeStreamReq get describe => $_getN(4);
+  @$pb.TagNumber(5)
+  set describe(DescribeStreamReq v) {
+    setField(5, v);
+  }
+
+  @$pb.TagNumber(5)
+  $core.bool hasDescribe() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearDescribe() => clearField(5);
+  @$pb.TagNumber(5)
+  DescribeStreamReq ensureDescribe() => $_ensure(4);
+
+  @$pb.TagNumber(6)
+  StoreSqlReq get storeSql => $_getN(5);
+  @$pb.TagNumber(6)
+  set storeSql(StoreSqlReq v) {
+    setField(6, v);
+  }
+
+  @$pb.TagNumber(6)
+  $core.bool hasStoreSql() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearStoreSql() => clearField(6);
+  @$pb.TagNumber(6)
+  StoreSqlReq ensureStoreSql() => $_ensure(5);
+
+  @$pb.TagNumber(7)
+  CloseSqlReq get closeSql => $_getN(6);
+  @$pb.TagNumber(7)
+  set closeSql(CloseSqlReq v) {
+    setField(7, v);
+  }
+
+  @$pb.TagNumber(7)
+  $core.bool hasCloseSql() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearCloseSql() => clearField(7);
+  @$pb.TagNumber(7)
+  CloseSqlReq ensureCloseSql() => $_ensure(6);
+
+  @$pb.TagNumber(8)
+  GetAutocommitReq get getAutocommit => $_getN(7);
+  @$pb.TagNumber(8)
+  set getAutocommit(GetAutocommitReq v) {
+    setField(8, v);
+  }
+
+  @$pb.TagNumber(8)
+  $core.bool hasGetAutocommit() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearGetAutocommit() => clearField(8);
+  @$pb.TagNumber(8)
+  GetAutocommitReq ensureGetAutocommit() => $_ensure(7);
+}
+
+class ExecuteStreamReq extends $pb.GeneratedMessage {
+  factory ExecuteStreamReq({
+    Stmt? stmt,
+  }) {
+    final $result = create();
+    if (stmt != null) {
+      $result.stmt = stmt;
+    }
+    return $result;
+  }
+  ExecuteStreamReq._() : super();
+  factory ExecuteStreamReq.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ExecuteStreamReq.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ExecuteStreamReq',
+      createEmptyInstance: create)
+    ..aOM<Stmt>(1, _omitFieldNames ? '' : 'stmt', subBuilder: Stmt.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  ExecuteStreamReq clone() => ExecuteStreamReq()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ExecuteStreamReq copyWith(void Function(ExecuteStreamReq) updates) =>
+      super.copyWith((message) => updates(message as ExecuteStreamReq))
+          as ExecuteStreamReq;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ExecuteStreamReq create() => ExecuteStreamReq._();
+  ExecuteStreamReq createEmptyInstance() => create();
+  static $pb.PbList<ExecuteStreamReq> createRepeated() =>
+      $pb.PbList<ExecuteStreamReq>();
+  @$core.pragma('dart2js:noInline')
+  static ExecuteStreamReq getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ExecuteStreamReq>(create);
+  static ExecuteStreamReq? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  Stmt get stmt => $_getN(0);
+  @$pb.TagNumber(1)
+  set stmt(Stmt v) {
+    setField(1, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasStmt() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearStmt() => clearField(1);
+  @$pb.TagNumber(1)
+  Stmt ensureStmt() => $_ensure(0);
+}
+
+class BatchStreamReq extends $pb.GeneratedMessage {
+  factory BatchStreamReq({
+    Batch? batch,
+  }) {
+    final $result = create();
+    if (batch != null) {
+      $result.batch = batch;
+    }
+    return $result;
+  }
+  BatchStreamReq._() : super();
+  factory BatchStreamReq.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory BatchStreamReq.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'BatchStreamReq',
+      createEmptyInstance: create)
+    ..aOM<Batch>(1, _omitFieldNames ? '' : 'batch', subBuilder: Batch.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  BatchStreamReq clone() => BatchStreamReq()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  BatchStreamReq copyWith(void Function(BatchStreamReq) updates) =>
+      super.copyWith((message) => updates(message as BatchStreamReq))
+          as BatchStreamReq;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BatchStreamReq create() => BatchStreamReq._();
+  BatchStreamReq createEmptyInstance() => create();
+  static $pb.PbList<BatchStreamReq> createRepeated() =>
+      $pb.PbList<BatchStreamReq>();
+  @$core.pragma('dart2js:noInline')
+  static BatchStreamReq getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<BatchStreamReq>(create);
+  static BatchStreamReq? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  Batch get batch => $_getN(0);
+  @$pb.TagNumber(1)
+  set batch(Batch v) {
+    setField(1, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasBatch() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearBatch() => clearField(1);
+  @$pb.TagNumber(1)
+  Batch ensureBatch() => $_ensure(0);
+}
+
+class SequenceStreamReq extends $pb.GeneratedMessage {
+  factory SequenceStreamReq({
+    $core.String? sql,
+    $core.int? sqlId,
+  }) {
+    final $result = create();
+    if (sql != null) {
+      $result.sql = sql;
+    }
+    if (sqlId != null) {
+      $result.sqlId = sqlId;
+    }
+    return $result;
+  }
+  SequenceStreamReq._() : super();
+  factory SequenceStreamReq.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SequenceStreamReq.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'SequenceStreamReq',
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sql')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'sqlId', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  SequenceStreamReq clone() => SequenceStreamReq()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SequenceStreamReq copyWith(void Function(SequenceStreamReq) updates) =>
+      super.copyWith((message) => updates(message as SequenceStreamReq))
+          as SequenceStreamReq;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SequenceStreamReq create() => SequenceStreamReq._();
+  SequenceStreamReq createEmptyInstance() => create();
+  static $pb.PbList<SequenceStreamReq> createRepeated() =>
+      $pb.PbList<SequenceStreamReq>();
+  @$core.pragma('dart2js:noInline')
+  static SequenceStreamReq getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<SequenceStreamReq>(create);
+  static SequenceStreamReq? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sql => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sql($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasSql() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSql() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get sqlId => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set sqlId($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasSqlId() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSqlId() => clearField(2);
+}
+
+class DescribeStreamReq extends $pb.GeneratedMessage {
+  factory DescribeStreamReq({
+    $core.String? sql,
+    $core.int? sqlId,
+  }) {
+    final $result = create();
+    if (sql != null) {
+      $result.sql = sql;
+    }
+    if (sqlId != null) {
+      $result.sqlId = sqlId;
+    }
+    return $result;
+  }
+  DescribeStreamReq._() : super();
+  factory DescribeStreamReq.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory DescribeStreamReq.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'DescribeStreamReq',
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'sql')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'sqlId', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  DescribeStreamReq clone() => DescribeStreamReq()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  DescribeStreamReq copyWith(void Function(DescribeStreamReq) updates) =>
+      super.copyWith((message) => updates(message as DescribeStreamReq))
+          as DescribeStreamReq;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DescribeStreamReq create() => DescribeStreamReq._();
+  DescribeStreamReq createEmptyInstance() => create();
+  static $pb.PbList<DescribeStreamReq> createRepeated() =>
+      $pb.PbList<DescribeStreamReq>();
+  @$core.pragma('dart2js:noInline')
+  static DescribeStreamReq getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<DescribeStreamReq>(create);
+  static DescribeStreamReq? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get sql => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set sql($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasSql() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSql() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get sqlId => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set sqlId($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasSqlId() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSqlId() => clearField(2);
+}
+
+class PipelineResp extends $pb.GeneratedMessage {
+  factory PipelineResp({
+    $core.String? baton,
+    $core.String? baseUrl,
+    $core.Iterable<StreamResult>? results,
+  }) {
+    final $result = create();
+    if (baton != null) {
+      $result.baton = baton;
+    }
+    if (baseUrl != null) {
+      $result.baseUrl = baseUrl;
+    }
+    if (results != null) {
+      $result.results.addAll(results);
+    }
+    return $result;
+  }
+  PipelineResp._() : super();
+  factory PipelineResp.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PipelineResp.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PipelineResp',
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'baton')
+    ..aOS(2, _omitFieldNames ? '' : 'baseUrl')
+    ..pc<StreamResult>(3, _omitFieldNames ? '' : 'results', $pb.PbFieldType.PM,
+        subBuilder: StreamResult.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  PipelineResp clone() => PipelineResp()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  PipelineResp copyWith(void Function(PipelineResp) updates) =>
+      super.copyWith((message) => updates(message as PipelineResp))
+          as PipelineResp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PipelineResp create() => PipelineResp._();
+  PipelineResp createEmptyInstance() => create();
+  static $pb.PbList<PipelineResp> createRepeated() =>
+      $pb.PbList<PipelineResp>();
+  @$core.pragma('dart2js:noInline')
+  static PipelineResp getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<PipelineResp>(create);
+  static PipelineResp? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get baton => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set baton($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasBaton() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearBaton() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get baseUrl => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set baseUrl($core.String v) {
+    $_setString(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasBaseUrl() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearBaseUrl() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<StreamResult> get results => $_getList(2);
+}
+
+enum StreamResult_Result { ok, error, notSet }
+
+class StreamResult extends $pb.GeneratedMessage {
+  factory StreamResult({
+    StreamResponse? ok,
+    Error? error,
+  }) {
+    final $result = create();
+    if (ok != null) {
+      $result.ok = ok;
+    }
+    if (error != null) {
+      $result.error = error;
+    }
+    return $result;
+  }
+  StreamResult._() : super();
+  factory StreamResult.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StreamResult.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static const $core.Map<$core.int, StreamResult_Result>
+      _StreamResult_ResultByTag = {
+    1: StreamResult_Result.ok,
+    2: StreamResult_Result.error,
+    0: StreamResult_Result.notSet
+  };
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StreamResult',
+      createEmptyInstance: create)
+    ..oo(0, [1, 2])
+    ..aOM<StreamResponse>(1, _omitFieldNames ? '' : 'ok',
+        subBuilder: StreamResponse.create)
+    ..aOM<Error>(2, _omitFieldNames ? '' : 'error', subBuilder: Error.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  StreamResult clone() => StreamResult()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StreamResult copyWith(void Function(StreamResult) updates) =>
+      super.copyWith((message) => updates(message as StreamResult))
+          as StreamResult;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StreamResult create() => StreamResult._();
+  StreamResult createEmptyInstance() => create();
+  static $pb.PbList<StreamResult> createRepeated() =>
+      $pb.PbList<StreamResult>();
+  @$core.pragma('dart2js:noInline')
+  static StreamResult getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<StreamResult>(create);
+  static StreamResult? _defaultInstance;
+
+  StreamResult_Result whichResult() =>
+      _StreamResult_ResultByTag[$_whichOneof(0)]!;
+  void clearResult() => clearField($_whichOneof(0));
+
+  @$pb.TagNumber(1)
+  StreamResponse get ok => $_getN(0);
+  @$pb.TagNumber(1)
+  set ok(StreamResponse v) {
+    setField(1, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasOk() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearOk() => clearField(1);
+  @$pb.TagNumber(1)
+  StreamResponse ensureOk() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  Error get error => $_getN(1);
+  @$pb.TagNumber(2)
+  set error(Error v) {
+    setField(2, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasError() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearError() => clearField(2);
+  @$pb.TagNumber(2)
+  Error ensureError() => $_ensure(1);
+}
+
+enum StreamResponse_Response {
+  close,
+  execute,
+  batch,
+  sequence,
+  describe,
+  storeSql,
+  closeSql,
+  getAutocommit,
+  notSet
+}
+
+class StreamResponse extends $pb.GeneratedMessage {
+  factory StreamResponse({
+    CloseStreamResp? close,
+    ExecuteResp? execute,
+    BatchResp? batch,
+    SequenceResp? sequence,
+    DescribeResp? describe,
+    StoreSqlResp? storeSql,
+    CloseSqlResp? closeSql,
+    GetAutocommitResp? getAutocommit,
+  }) {
+    final $result = create();
+    if (close != null) {
+      $result.close = close;
+    }
+    if (execute != null) {
+      $result.execute = execute;
+    }
+    if (batch != null) {
+      $result.batch = batch;
+    }
+    if (sequence != null) {
+      $result.sequence = sequence;
+    }
+    if (describe != null) {
+      $result.describe = describe;
+    }
+    if (storeSql != null) {
+      $result.storeSql = storeSql;
+    }
+    if (closeSql != null) {
+      $result.closeSql = closeSql;
+    }
+    if (getAutocommit != null) {
+      $result.getAutocommit = getAutocommit;
+    }
+    return $result;
+  }
+  StreamResponse._() : super();
+  factory StreamResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StreamResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+
+  static const $core.Map<$core.int, StreamResponse_Response>
+      _StreamResponse_ResponseByTag = {
+    1: StreamResponse_Response.close,
+    2: StreamResponse_Response.execute,
+    3: StreamResponse_Response.batch,
+    4: StreamResponse_Response.sequence,
+    5: StreamResponse_Response.describe,
+    6: StreamResponse_Response.storeSql,
+    7: StreamResponse_Response.closeSql,
+    8: StreamResponse_Response.getAutocommit,
+    0: StreamResponse_Response.notSet
+  };
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StreamResponse',
+      createEmptyInstance: create)
+    ..oo(0, [1, 2, 3, 4, 5, 6, 7, 8])
+    ..aOM<CloseStreamResp>(1, _omitFieldNames ? '' : 'close',
+        subBuilder: CloseStreamResp.create)
+    ..aOM<ExecuteResp>(2, _omitFieldNames ? '' : 'execute',
+        subBuilder: ExecuteResp.create)
+    ..aOM<BatchResp>(3, _omitFieldNames ? '' : 'batch',
+        subBuilder: BatchResp.create)
+    ..aOM<SequenceResp>(4, _omitFieldNames ? '' : 'sequence',
+        subBuilder: SequenceResp.create)
+    ..aOM<DescribeResp>(5, _omitFieldNames ? '' : 'describe',
+        subBuilder: DescribeResp.create)
+    ..aOM<StoreSqlResp>(6, _omitFieldNames ? '' : 'storeSql',
+        subBuilder: StoreSqlResp.create)
+    ..aOM<CloseSqlResp>(7, _omitFieldNames ? '' : 'closeSql',
+        subBuilder: CloseSqlResp.create)
+    ..aOM<GetAutocommitResp>(8, _omitFieldNames ? '' : 'getAutocommit',
+        subBuilder: GetAutocommitResp.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  StreamResponse clone() => StreamResponse()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  StreamResponse copyWith(void Function(StreamResponse) updates) =>
+      super.copyWith((message) => updates(message as StreamResponse))
+          as StreamResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StreamResponse create() => StreamResponse._();
+  StreamResponse createEmptyInstance() => create();
+  static $pb.PbList<StreamResponse> createRepeated() =>
+      $pb.PbList<StreamResponse>();
+  @$core.pragma('dart2js:noInline')
+  static StreamResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<StreamResponse>(create);
+  static StreamResponse? _defaultInstance;
+
+  StreamResponse_Response whichResponse() =>
+      _StreamResponse_ResponseByTag[$_whichOneof(0)]!;
+  void clearResponse() => clearField($_whichOneof(0));
+
+  @$pb.TagNumber(1)
+  CloseStreamResp get close => $_getN(0);
+  @$pb.TagNumber(1)
+  set close(CloseStreamResp v) {
+    setField(1, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasClose() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearClose() => clearField(1);
+  @$pb.TagNumber(1)
+  CloseStreamResp ensureClose() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  ExecuteResp get execute => $_getN(1);
+  @$pb.TagNumber(2)
+  set execute(ExecuteResp v) {
+    setField(2, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasExecute() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearExecute() => clearField(2);
+  @$pb.TagNumber(2)
+  ExecuteResp ensureExecute() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  BatchResp get batch => $_getN(2);
+  @$pb.TagNumber(3)
+  set batch(BatchResp v) {
+    setField(3, v);
+  }
+
+  @$pb.TagNumber(3)
+  $core.bool hasBatch() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearBatch() => clearField(3);
+  @$pb.TagNumber(3)
+  BatchResp ensureBatch() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  SequenceResp get sequence => $_getN(3);
+  @$pb.TagNumber(4)
+  set sequence(SequenceResp v) {
+    setField(4, v);
+  }
+
+  @$pb.TagNumber(4)
+  $core.bool hasSequence() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearSequence() => clearField(4);
+  @$pb.TagNumber(4)
+  SequenceResp ensureSequence() => $_ensure(3);
+
+  @$pb.TagNumber(5)
+  DescribeResp get describe => $_getN(4);
+  @$pb.TagNumber(5)
+  set describe(DescribeResp v) {
+    setField(5, v);
+  }
+
+  @$pb.TagNumber(5)
+  $core.bool hasDescribe() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearDescribe() => clearField(5);
+  @$pb.TagNumber(5)
+  DescribeResp ensureDescribe() => $_ensure(4);
+
+  @$pb.TagNumber(6)
+  StoreSqlResp get storeSql => $_getN(5);
+  @$pb.TagNumber(6)
+  set storeSql(StoreSqlResp v) {
+    setField(6, v);
+  }
+
+  @$pb.TagNumber(6)
+  $core.bool hasStoreSql() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearStoreSql() => clearField(6);
+  @$pb.TagNumber(6)
+  StoreSqlResp ensureStoreSql() => $_ensure(5);
+
+  @$pb.TagNumber(7)
+  CloseSqlResp get closeSql => $_getN(6);
+  @$pb.TagNumber(7)
+  set closeSql(CloseSqlResp v) {
+    setField(7, v);
+  }
+
+  @$pb.TagNumber(7)
+  $core.bool hasCloseSql() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearCloseSql() => clearField(7);
+  @$pb.TagNumber(7)
+  CloseSqlResp ensureCloseSql() => $_ensure(6);
+
+  @$pb.TagNumber(8)
+  GetAutocommitResp get getAutocommit => $_getN(7);
+  @$pb.TagNumber(8)
+  set getAutocommit(GetAutocommitResp v) {
+    setField(8, v);
+  }
+
+  @$pb.TagNumber(8)
+  $core.bool hasGetAutocommit() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearGetAutocommit() => clearField(8);
+  @$pb.TagNumber(8)
+  GetAutocommitResp ensureGetAutocommit() => $_ensure(7);
 }
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');

--- a/hrana/lib/src/protocol.pbjson.dart
+++ b/hrana/lib/src/protocol.pbjson.dart
@@ -105,9 +105,22 @@ const StmtResult$json = {
       '10': 'lastInsertRowid',
       '17': true
     },
+    {
+      '1': 'replication_index',
+      '3': 5,
+      '4': 1,
+      '5': 4,
+      '9': 1,
+      '10': 'replicationIndex',
+      '17': true
+    },
+    {'1': 'rows_read', '3': 6, '4': 1, '5': 4, '10': 'rowsRead'},
+    {'1': 'rows_written', '3': 7, '4': 1, '5': 4, '10': 'rowsWritten'},
+    {'1': 'query_duration_ms', '3': 8, '4': 1, '5': 1, '10': 'queryDurationMs'},
   ],
   '8': [
     {'1': '_last_insert_rowid'},
+    {'1': '_replication_index'},
   ],
 };
 
@@ -115,8 +128,11 @@ const StmtResult$json = {
 final $typed_data.Uint8List stmtResultDescriptor = $convert.base64Decode(
     'CgpTdG10UmVzdWx0EhgKBGNvbHMYASADKAsyBC5Db2xSBGNvbHMSGAoEcm93cxgCIAMoCzIELl'
     'Jvd1IEcm93cxIsChJhZmZlY3RlZF9yb3dfY291bnQYAyABKARSEGFmZmVjdGVkUm93Q291bnQS'
-    'LwoRbGFzdF9pbnNlcnRfcm93aWQYBCABKBJIAFIPbGFzdEluc2VydFJvd2lkiAEBQhQKEl9sYX'
-    'N0X2luc2VydF9yb3dpZA==');
+    'LwoRbGFzdF9pbnNlcnRfcm93aWQYBCABKBJIAFIPbGFzdEluc2VydFJvd2lkiAEBEjAKEXJlcG'
+    'xpY2F0aW9uX2luZGV4GAUgASgESAFSEHJlcGxpY2F0aW9uSW5kZXiIAQESGwoJcm93c19yZWFk'
+    'GAYgASgEUghyb3dzUmVhZBIhCgxyb3dzX3dyaXR0ZW4YByABKARSC3Jvd3NXcml0dGVuEioKEX'
+    'F1ZXJ5X2R1cmF0aW9uX21zGAggASgBUg9xdWVyeUR1cmF0aW9uTXNCFAoSX2xhc3RfaW5zZXJ0'
+    'X3Jvd2lkQhQKEl9yZXBsaWNhdGlvbl9pbmRleA==');
 
 @$core.Deprecated('Use colDescriptor instead')
 const Col$json = {
@@ -1260,3 +1276,341 @@ const GetAutocommitResp$json = {
 final $typed_data.Uint8List getAutocommitRespDescriptor = $convert.base64Decode(
     'ChFHZXRBdXRvY29tbWl0UmVzcBIjCg1pc19hdXRvY29tbWl0GAEgASgIUgxpc0F1dG9jb21taX'
     'Q=');
+
+@$core.Deprecated('Use pipelineReqDescriptor instead')
+const PipelineReq$json = {
+  '1': 'PipelineReq',
+  '2': [
+    {'1': 'baton', '3': 1, '4': 1, '5': 9, '9': 0, '10': 'baton', '17': true},
+    {
+      '1': 'requests',
+      '3': 2,
+      '4': 3,
+      '5': 11,
+      '6': '.StreamRequest',
+      '10': 'requests'
+    },
+  ],
+  '8': [
+    {'1': '_baton'},
+  ],
+};
+
+/// Descriptor for `PipelineReq`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List pipelineReqDescriptor = $convert.base64Decode(
+    'CgtQaXBlbGluZVJlcRIZCgViYXRvbhgBIAEoCUgAUgViYXRvbogBARIqCghyZXF1ZXN0cxgCIA'
+    'MoCzIOLlN0cmVhbVJlcXVlc3RSCHJlcXVlc3RzQggKBl9iYXRvbg==');
+
+@$core.Deprecated('Use streamRequestDescriptor instead')
+const StreamRequest$json = {
+  '1': 'StreamRequest',
+  '2': [
+    {
+      '1': 'close',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.CloseStreamReq',
+      '9': 0,
+      '10': 'close'
+    },
+    {
+      '1': 'execute',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.ExecuteStreamReq',
+      '9': 0,
+      '10': 'execute'
+    },
+    {
+      '1': 'batch',
+      '3': 3,
+      '4': 1,
+      '5': 11,
+      '6': '.BatchStreamReq',
+      '9': 0,
+      '10': 'batch'
+    },
+    {
+      '1': 'sequence',
+      '3': 4,
+      '4': 1,
+      '5': 11,
+      '6': '.SequenceStreamReq',
+      '9': 0,
+      '10': 'sequence'
+    },
+    {
+      '1': 'describe',
+      '3': 5,
+      '4': 1,
+      '5': 11,
+      '6': '.DescribeStreamReq',
+      '9': 0,
+      '10': 'describe'
+    },
+    {
+      '1': 'store_sql',
+      '3': 6,
+      '4': 1,
+      '5': 11,
+      '6': '.StoreSqlReq',
+      '9': 0,
+      '10': 'storeSql'
+    },
+    {
+      '1': 'close_sql',
+      '3': 7,
+      '4': 1,
+      '5': 11,
+      '6': '.CloseSqlReq',
+      '9': 0,
+      '10': 'closeSql'
+    },
+    {
+      '1': 'get_autocommit',
+      '3': 8,
+      '4': 1,
+      '5': 11,
+      '6': '.GetAutocommitReq',
+      '9': 0,
+      '10': 'getAutocommit'
+    },
+  ],
+  '8': [
+    {'1': 'request'},
+  ],
+};
+
+/// Descriptor for `StreamRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List streamRequestDescriptor = $convert.base64Decode(
+    'Cg1TdHJlYW1SZXF1ZXN0EicKBWNsb3NlGAEgASgLMg8uQ2xvc2VTdHJlYW1SZXFIAFIFY2xvc2'
+    'USLQoHZXhlY3V0ZRgCIAEoCzIRLkV4ZWN1dGVTdHJlYW1SZXFIAFIHZXhlY3V0ZRInCgViYXRj'
+    'aBgDIAEoCzIPLkJhdGNoU3RyZWFtUmVxSABSBWJhdGNoEjAKCHNlcXVlbmNlGAQgASgLMhIuU2'
+    'VxdWVuY2VTdHJlYW1SZXFIAFIIc2VxdWVuY2USMAoIZGVzY3JpYmUYBSABKAsyEi5EZXNjcmli'
+    'ZVN0cmVhbVJlcUgAUghkZXNjcmliZRIrCglzdG9yZV9zcWwYBiABKAsyDC5TdG9yZVNxbFJlcU'
+    'gAUghzdG9yZVNxbBIrCgljbG9zZV9zcWwYByABKAsyDC5DbG9zZVNxbFJlcUgAUghjbG9zZVNx'
+    'bBI6Cg5nZXRfYXV0b2NvbW1pdBgIIAEoCzIRLkdldEF1dG9jb21taXRSZXFIAFINZ2V0QXV0b2'
+    'NvbW1pdEIJCgdyZXF1ZXN0');
+
+@$core.Deprecated('Use executeStreamReqDescriptor instead')
+const ExecuteStreamReq$json = {
+  '1': 'ExecuteStreamReq',
+  '2': [
+    {'1': 'stmt', '3': 1, '4': 1, '5': 11, '6': '.Stmt', '10': 'stmt'},
+  ],
+};
+
+/// Descriptor for `ExecuteStreamReq`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List executeStreamReqDescriptor = $convert.base64Decode(
+    'ChBFeGVjdXRlU3RyZWFtUmVxEhkKBHN0bXQYASABKAsyBS5TdG10UgRzdG10');
+
+@$core.Deprecated('Use batchStreamReqDescriptor instead')
+const BatchStreamReq$json = {
+  '1': 'BatchStreamReq',
+  '2': [
+    {'1': 'batch', '3': 1, '4': 1, '5': 11, '6': '.Batch', '10': 'batch'},
+  ],
+};
+
+/// Descriptor for `BatchStreamReq`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List batchStreamReqDescriptor = $convert.base64Decode(
+    'Cg5CYXRjaFN0cmVhbVJlcRIcCgViYXRjaBgBIAEoCzIGLkJhdGNoUgViYXRjaA==');
+
+@$core.Deprecated('Use sequenceStreamReqDescriptor instead')
+const SequenceStreamReq$json = {
+  '1': 'SequenceStreamReq',
+  '2': [
+    {'1': 'sql', '3': 1, '4': 1, '5': 9, '9': 0, '10': 'sql', '17': true},
+    {'1': 'sql_id', '3': 2, '4': 1, '5': 5, '9': 1, '10': 'sqlId', '17': true},
+  ],
+  '8': [
+    {'1': '_sql'},
+    {'1': '_sql_id'},
+  ],
+};
+
+/// Descriptor for `SequenceStreamReq`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List sequenceStreamReqDescriptor = $convert.base64Decode(
+    'ChFTZXF1ZW5jZVN0cmVhbVJlcRIVCgNzcWwYASABKAlIAFIDc3FsiAEBEhoKBnNxbF9pZBgCIA'
+    'EoBUgBUgVzcWxJZIgBAUIGCgRfc3FsQgkKB19zcWxfaWQ=');
+
+@$core.Deprecated('Use describeStreamReqDescriptor instead')
+const DescribeStreamReq$json = {
+  '1': 'DescribeStreamReq',
+  '2': [
+    {'1': 'sql', '3': 1, '4': 1, '5': 9, '9': 0, '10': 'sql', '17': true},
+    {'1': 'sql_id', '3': 2, '4': 1, '5': 5, '9': 1, '10': 'sqlId', '17': true},
+  ],
+  '8': [
+    {'1': '_sql'},
+    {'1': '_sql_id'},
+  ],
+};
+
+/// Descriptor for `DescribeStreamReq`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List describeStreamReqDescriptor = $convert.base64Decode(
+    'ChFEZXNjcmliZVN0cmVhbVJlcRIVCgNzcWwYASABKAlIAFIDc3FsiAEBEhoKBnNxbF9pZBgCIA'
+    'EoBUgBUgVzcWxJZIgBAUIGCgRfc3FsQgkKB19zcWxfaWQ=');
+
+@$core.Deprecated('Use pipelineRespDescriptor instead')
+const PipelineResp$json = {
+  '1': 'PipelineResp',
+  '2': [
+    {'1': 'baton', '3': 1, '4': 1, '5': 9, '9': 0, '10': 'baton', '17': true},
+    {
+      '1': 'base_url',
+      '3': 2,
+      '4': 1,
+      '5': 9,
+      '9': 1,
+      '10': 'baseUrl',
+      '17': true
+    },
+    {
+      '1': 'results',
+      '3': 3,
+      '4': 3,
+      '5': 11,
+      '6': '.StreamResult',
+      '10': 'results'
+    },
+  ],
+  '8': [
+    {'1': '_baton'},
+    {'1': '_base_url'},
+  ],
+};
+
+/// Descriptor for `PipelineResp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List pipelineRespDescriptor = $convert.base64Decode(
+    'CgxQaXBlbGluZVJlc3ASGQoFYmF0b24YASABKAlIAFIFYmF0b26IAQESHgoIYmFzZV91cmwYAi'
+    'ABKAlIAVIHYmFzZVVybIgBARInCgdyZXN1bHRzGAMgAygLMg0uU3RyZWFtUmVzdWx0UgdyZXN1'
+    'bHRzQggKBl9iYXRvbkILCglfYmFzZV91cmw=');
+
+@$core.Deprecated('Use streamResultDescriptor instead')
+const StreamResult$json = {
+  '1': 'StreamResult',
+  '2': [
+    {
+      '1': 'ok',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.StreamResponse',
+      '9': 0,
+      '10': 'ok'
+    },
+    {
+      '1': 'error',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.Error',
+      '9': 0,
+      '10': 'error'
+    },
+  ],
+  '8': [
+    {'1': 'result'},
+  ],
+};
+
+/// Descriptor for `StreamResult`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List streamResultDescriptor = $convert.base64Decode(
+    'CgxTdHJlYW1SZXN1bHQSIQoCb2sYASABKAsyDy5TdHJlYW1SZXNwb25zZUgAUgJvaxIeCgVlcn'
+    'JvchgCIAEoCzIGLkVycm9ySABSBWVycm9yQggKBnJlc3VsdA==');
+
+@$core.Deprecated('Use streamResponseDescriptor instead')
+const StreamResponse$json = {
+  '1': 'StreamResponse',
+  '2': [
+    {
+      '1': 'close',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.CloseStreamResp',
+      '9': 0,
+      '10': 'close'
+    },
+    {
+      '1': 'execute',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.ExecuteResp',
+      '9': 0,
+      '10': 'execute'
+    },
+    {
+      '1': 'batch',
+      '3': 3,
+      '4': 1,
+      '5': 11,
+      '6': '.BatchResp',
+      '9': 0,
+      '10': 'batch'
+    },
+    {
+      '1': 'sequence',
+      '3': 4,
+      '4': 1,
+      '5': 11,
+      '6': '.SequenceResp',
+      '9': 0,
+      '10': 'sequence'
+    },
+    {
+      '1': 'describe',
+      '3': 5,
+      '4': 1,
+      '5': 11,
+      '6': '.DescribeResp',
+      '9': 0,
+      '10': 'describe'
+    },
+    {
+      '1': 'store_sql',
+      '3': 6,
+      '4': 1,
+      '5': 11,
+      '6': '.StoreSqlResp',
+      '9': 0,
+      '10': 'storeSql'
+    },
+    {
+      '1': 'close_sql',
+      '3': 7,
+      '4': 1,
+      '5': 11,
+      '6': '.CloseSqlResp',
+      '9': 0,
+      '10': 'closeSql'
+    },
+    {
+      '1': 'get_autocommit',
+      '3': 8,
+      '4': 1,
+      '5': 11,
+      '6': '.GetAutocommitResp',
+      '9': 0,
+      '10': 'getAutocommit'
+    },
+  ],
+  '8': [
+    {'1': 'response'},
+  ],
+};
+
+/// Descriptor for `StreamResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List streamResponseDescriptor = $convert.base64Decode(
+    'Cg5TdHJlYW1SZXNwb25zZRIoCgVjbG9zZRgBIAEoCzIQLkNsb3NlU3RyZWFtUmVzcEgAUgVjbG'
+    '9zZRIoCgdleGVjdXRlGAIgASgLMgwuRXhlY3V0ZVJlc3BIAFIHZXhlY3V0ZRIiCgViYXRjaBgD'
+    'IAEoCzIKLkJhdGNoUmVzcEgAUgViYXRjaBIrCghzZXF1ZW5jZRgEIAEoCzINLlNlcXVlbmNlUm'
+    'VzcEgAUghzZXF1ZW5jZRIrCghkZXNjcmliZRgFIAEoCzINLkRlc2NyaWJlUmVzcEgAUghkZXNj'
+    'cmliZRIsCglzdG9yZV9zcWwYBiABKAsyDS5TdG9yZVNxbFJlc3BIAFIIc3RvcmVTcWwSLAoJY2'
+    'xvc2Vfc3FsGAcgASgLMg0uQ2xvc2VTcWxSZXNwSABSCGNsb3NlU3FsEjsKDmdldF9hdXRvY29t'
+    'bWl0GAggASgLMhIuR2V0QXV0b2NvbW1pdFJlc3BIAFINZ2V0QXV0b2NvbW1pdEIKCghyZXNwb2'
+    '5zZQ==');

--- a/hrana/lib/src/protocol.proto
+++ b/hrana/lib/src/protocol.proto
@@ -1,3 +1,7 @@
+// Adapted from: 
+// - https://github.com/tursodatabase/libsql/blob/main/docs/HRANA_3_SPEC.md
+// - https://github.com/tursodatabase/libsql/blob/main/libsql-hrana/src/proto.rs
+
 syntax = "proto3";
 
 message Error {
@@ -23,6 +27,10 @@ message StmtResult {
   repeated Row rows = 2;
   uint64 affected_row_count = 3;
   optional sint64 last_insert_rowid = 4;
+  optional uint64 replication_index = 5;
+  uint64 rows_read = 6;
+  uint64 rows_written = 7;
+  double query_duration_ms = 8;
 }
 
 message Col {
@@ -206,6 +214,10 @@ message ExecuteReq {
   Stmt stmt = 2;
 }
 
+message ExecuteStreamReq {
+  Stmt stmt = 1;
+}
+
 message ExecuteResp {
   StmtResult result = 1;
 }
@@ -213,6 +225,10 @@ message ExecuteResp {
 message BatchReq {
   int32 stream_id = 1;
   Batch batch = 2;
+}
+
+message BatchStreamReq {
+  Batch batch = 1;
 }
 
 message BatchResp {
@@ -266,6 +282,11 @@ message SequenceReq {
   optional int32 sql_id = 3;
 }
 
+message SequenceStreamReq {
+  optional string sql = 1;
+  optional int32 sql_id = 2;
+}
+
 message SequenceResp {
 }
 
@@ -273,6 +294,11 @@ message DescribeReq {
   int32 stream_id = 1;
   optional string sql = 2;
   optional int32 sql_id = 3;
+}
+
+message DescribeStreamReq {
+  optional string sql = 1;
+  optional int32 sql_id = 2;
 }
 
 message DescribeResp {
@@ -283,6 +309,52 @@ message GetAutocommitReq {
   int32 stream_id = 1;
 }
 
+message GetAutocommitStreamReq {}
+
 message GetAutocommitResp {
   bool is_autocommit = 1;
+}
+
+message PipelineReq {
+  optional string baton = 1;
+  repeated StreamRequest requests = 2;
+}
+
+message StreamRequest {
+  oneof request {
+    CloseStreamReq close = 1;
+    ExecuteStreamReq execute = 2;
+    BatchStreamReq batch = 3;
+    SequenceStreamReq sequence = 4;
+    DescribeStreamReq describe = 5;
+    StoreSqlReq store_sql = 6;
+    CloseSqlReq close_sql = 7;
+    GetAutocommitStreamReq get_autocommit = 8;
+  }
+}
+
+message PipelineResp {
+  optional string baton = 1;
+  optional string base_url = 2;
+  repeated StreamResult results = 3;
+}
+
+message StreamResult {
+  oneof result {
+    StreamResponse ok = 1;
+    Error error = 2;
+  }
+}
+
+message StreamResponse {
+  oneof response {
+    CloseStreamResp close = 1;
+    ExecuteResp execute = 2;
+    BatchResp batch = 3;
+    SequenceResp sequence = 4;
+    DescribeResp describe = 5;
+    StoreSqlResp store_sql = 6;
+    CloseSqlResp close_sql = 7;
+    GetAutocommitResp get_autocommit = 8;
+  }
 }

--- a/hrana/lib/src/rpc_client.dart
+++ b/hrana/lib/src/rpc_client.dart
@@ -1,153 +1,18 @@
-import 'dart:async';
-import 'dart:typed_data';
-
 import 'package:fixnum/fixnum.dart';
-import 'package:stream_channel/stream_channel.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
 
-import 'exception.dart';
 import 'protocol.pb.dart' as proto;
 
-final class HranaClient {
-  final StreamChannel<dynamic> _channel;
-  bool _closed = false;
-  final Completer<void> _streamClosed = Completer();
-
-  Completer<void>? _helloCompleter;
-  final Map<int, Completer<proto.ResponseOkMsg>> _pendingRequests = {};
-  int _nextRequestId = 0;
-  int _nextStreamId = 0;
-  int _nextSqlTextId = 0;
-
-  HranaClient._(this._channel) {
-    _channel.stream.listen((data) {
-      if (data is Uint8List) {
-        _handleMessage(data);
-      } else {
-        throw 'Unexpected message: $data';
-      }
-    }, onDone: _closedByRemote);
-  }
-
-  bool get isClosed => _closed;
-  Future<void> get closed => _streamClosed.future;
-
-  void _closedByRemote() {
-    _closed = true;
-    for (final pending in _pendingRequests.values) {
-      pending.completeError(const ConnectionClosed());
-    }
-    _streamClosed.complete();
-  }
-
-  Future<void> close() async {
-    _closed = true;
-    if (_channel case WebSocketChannel ws) {
-      await ws.sink.close(1000, 'connection closed');
-    } else {
-      await _channel.sink.close();
-    }
-
-    await _streamClosed.future;
-  }
-
-  Future<SqlStreamId> openStream() async {
-    final streamId = _nextStreamId++;
-    await _request(
-        proto.RequestMsg(openStream: proto.OpenStreamReq(streamId: streamId)));
-    return SqlStreamId(streamId);
-  }
-
-  Future<void> closeStream(SqlStreamId id) async {
-    await _request(
-        proto.RequestMsg(closeStream: proto.CloseStreamReq(streamId: id.id)));
-  }
-
+abstract interface class HranaClient {
+  Future<SqlStreamId> openStream();
+  Future<void> closeStream(SqlStreamId id);
   Future<StatementResult> executeStatement(
-      SqlStreamId stream, StatementDescription stmt) async {
-    final response = await _request(proto.RequestMsg(
-      execute: proto.ExecuteReq(
-        streamId: stream.id,
-        stmt: stmt.toStatement(),
-      ),
-    ));
-
-    return StatementResult.fromProto(response.execute.result);
-  }
-
-  Future<SqlTextId> storeSql(String sql) async {
-    final textId = _nextSqlTextId++;
-    await _request(
-        proto.RequestMsg(storeSql: proto.StoreSqlReq(sqlId: textId, sql: sql)));
-    return SqlTextId(textId);
-  }
-
-  Future<void> closeSql(SqlTextId id) async {
-    await _request(proto.RequestMsg(closeSql: proto.CloseSqlReq(sqlId: id.id)));
-  }
-
-  Future<proto.BatchResult> runBatch(
-      SqlStreamId stream, proto.Batch batch) async {
-    final response = await _request(proto.RequestMsg(
-        batch: proto.BatchReq(batch: batch, streamId: stream.id)));
-    return response.batch.result;
-  }
-
-  Future<void> _hello(String? jwt) async {
-    final completer = _helloCompleter = Completer();
-    _send(proto.ClientMsg(hello: proto.HelloMsg(jwt: jwt)));
-    await completer.future;
-    _helloCompleter = null;
-  }
-
-  Future<proto.ResponseOkMsg> _request(proto.RequestMsg request) async {
-    final id = _nextRequestId++;
-    final completer = Completer<proto.ResponseOkMsg>();
-    _pendingRequests[id] = completer;
-    _send(proto.ClientMsg(request: request..requestId = id));
-
-    return await completer.future;
-  }
-
-  void _send(proto.ClientMsg msg) {
-    if (_closed) {
-      throw const ConnectionClosed();
-    }
-
-    _channel.sink.add(msg.writeToBuffer());
-  }
-
-  void _handleMessage(Uint8List data) {
-    final msg = proto.ServerMsg.fromBuffer(data);
-
-    if (msg.hasHelloOk()) {
-      _helloCompleter?.complete();
-    } else if (msg.hasHelloError()) {
-      _helloCompleter?.completeError(createError(msg.helloError.error));
-    } else if (msg.hasResponseOk()) {
-      final id = msg.responseOk.requestId;
-      final completer = _pendingRequests.remove(id);
-      completer?.complete(msg.responseOk);
-    } else if (msg.hasResponseError()) {
-      final id = msg.responseError.requestId;
-      final completer = _pendingRequests.remove(id);
-      completer?.completeError(createError(msg.responseError.error));
-    }
-  }
-
-  static HranaException createError(proto.Error error) {
-    return ServerException(message: error.message, code: error.code);
-  }
-
-  static Future<HranaClient> connect(Uri uri, {String? jwtToken}) async {
-    final channel =
-        WebSocketChannel.connect(uri, protocols: ['hrana3-protobuf']);
-    await channel.ready;
-
-    final client = HranaClient._(channel);
-    await client._hello(jwtToken);
-    return client;
-  }
+      SqlStreamId stream, StatementDescription stmt);
+  Future<SqlTextId> storeSql(SqlStreamId stream, String sql);
+  Future<void> closeSql(SqlStreamId stream, SqlTextId id);
+  Future<proto.BatchResult> runBatch(SqlStreamId stream, proto.Batch batch);
+  Future<void> close();
+  bool get isClosed;
+  Future<void> get closed;
 }
 
 extension type SqlStreamId(int id) {}
@@ -293,7 +158,7 @@ final class StatementResult {
       ],
       affectedRowCount: result.affectedRowCount.toInt(),
       lastInsertRowId:
-          result.hasLastInsertRowid() ? null : result.lastInsertRowid.toInt(),
+          result.hasLastInsertRowid() ? result.lastInsertRowid.toInt() : null,
     );
   }
 

--- a/hrana/lib/src/rpc_http_client.dart
+++ b/hrana/lib/src/rpc_http_client.dart
@@ -1,0 +1,267 @@
+import 'dart:async';
+import 'dart:developer';
+
+import 'package:hrana/src/exception.dart';
+import 'package:hrana/src/protocol.pb.dart' as proto;
+import 'package:hrana/src/rpc_client.dart';
+import 'package:http/http.dart' as http;
+
+final class HranaHttpClient implements HranaClient {
+  HranaHttpClient._(
+    this._uri, {
+    String? jwtToken,
+    http.Client? httpClient,
+  }) : _httpClient = _AuthorizingHttpClient(
+          inner: httpClient,
+          jwtToken: jwtToken,
+        );
+
+  final Uri _uri;
+  final http.Client _httpClient;
+  final Completer<void> _closed = Completer();
+
+  var _nextStreamId = 0;
+  var _nextSqlTextId = 0;
+  final Map<SqlStreamId, _SqlStreamInfo> _streams = {};
+
+  static void _log(String message) {
+    log(
+      message,
+      name: 'Hrana',
+      level: 300, // Level.FINEST
+    );
+  }
+
+  static Future<HranaHttpClient> connect(
+    Uri uri, {
+    String? jwtToken,
+    http.Client? httpClient,
+  }) async {
+    final client = HranaHttpClient._(
+      uri,
+      jwtToken: jwtToken,
+      httpClient: httpClient,
+    );
+    await client._ensureProtocolSupport();
+    return client;
+  }
+
+  /// Ensures that the server supports the Hrana V3 Protobuf protocol.
+  Future<void> _ensureProtocolSupport() async {
+    final url = _uri.resolve('./v3-protobuf');
+    final response = await _httpClient.get(url);
+    if (response.statusCode >= 300) {
+      throw ServerException(
+        message: 'Server does not support Hrana V3 Protobuf protocol: '
+            '"${response.body}"',
+        code: response.statusCode.toString(),
+      );
+    }
+  }
+
+  Future<proto.StreamResponse> _runPipeline({
+    SqlStreamId? streamId,
+    required proto.StreamRequest? request,
+  }) async {
+    final streamInfo = _streams[streamId];
+    final baseUri = streamInfo?.baseUri ?? _uri;
+    final url = baseUri.resolve('./v3-protobuf/pipeline');
+    final pipelineReq = proto.PipelineReq(
+      baton: streamInfo?.baton,
+      requests: request == null ? const [] : [request],
+    );
+    _log('Sending request:\n$request');
+    final piplineResp = await _httpClient.post(
+      url,
+      headers: {
+        'Content-Type': 'application/protobuf',
+        'Accept': 'application/protobuf',
+      },
+      body: pipelineReq.writeToBuffer(),
+    );
+    if (piplineResp.statusCode >= 300) {
+      throw ServerException(
+        message: 'Failed to run pipeline: "${piplineResp.body}"',
+        code: piplineResp.statusCode.toString(),
+      );
+    }
+    final response = proto.PipelineResp.fromBuffer(piplineResp.bodyBytes);
+    final expectsBaton = request == null || !request.hasClose();
+    if (!response.hasBaton() && expectsBaton) {
+      // The server has closed the stream.
+      _streams.remove(streamId);
+      throw const ConnectionClosed();
+    }
+    if (streamId != null) {
+      _streams[streamId] = (
+        baton: response.baton,
+        baseUri: switch (response.baseUrl) {
+          '' => null,
+          final url => Uri.parse(url),
+        },
+      );
+    }
+    if (response.results.isEmpty && request == null) {
+      _log('Opened stream');
+      return proto.StreamResponse();
+    }
+    final result = response.results.single;
+    _log('Received response:\n$result');
+    return switch (result.whichResult()) {
+      proto.StreamResult_Result.ok => result.ok,
+      proto.StreamResult_Result.error => throw ServerException(
+          message: result.error.message,
+          code: result.error.code,
+        ),
+      _ => throw ServerException(
+          message: 'Unexpected response: $response',
+          code: null,
+        ),
+    };
+  }
+
+  @override
+  Future<SqlStreamId> openStream() async {
+    if (_isClosed) {
+      throw const ConnectionClosed();
+    }
+    final streamId = SqlStreamId(_nextStreamId++);
+    await _runPipeline(
+      streamId: streamId,
+      request: null,
+    );
+    return streamId;
+  }
+
+  @override
+  Future<void> closeStream(SqlStreamId id) async {
+    if (_isClosed) {
+      throw const ConnectionClosed();
+    }
+    try {
+      final response = await _runPipeline(
+        streamId: id,
+        request: proto.StreamRequest(close: proto.CloseStreamReq()),
+      );
+      assert(response.whichResponse() == proto.StreamResponse_Response.close);
+    } finally {
+      _streams.remove(id);
+    }
+  }
+
+  @override
+  Future<StatementResult> executeStatement(
+    SqlStreamId stream,
+    StatementDescription stmt,
+  ) async {
+    if (_isClosed) {
+      throw const ConnectionClosed();
+    }
+    final response = await _runPipeline(
+      streamId: stream,
+      request: proto.StreamRequest(
+        execute: proto.ExecuteStreamReq(stmt: stmt.toStatement()),
+      ),
+    );
+    assert(response.whichResponse() == proto.StreamResponse_Response.execute);
+    return StatementResult.fromProto(response.execute.result);
+  }
+
+  @override
+  Future<proto.BatchResult> runBatch(
+    SqlStreamId stream,
+    proto.Batch batch,
+  ) async {
+    if (_isClosed) {
+      throw const ConnectionClosed();
+    }
+    final response = await _runPipeline(
+      streamId: stream,
+      request: proto.StreamRequest(batch: proto.BatchStreamReq(batch: batch)),
+    );
+    assert(response.whichResponse() == proto.StreamResponse_Response.batch);
+    return response.batch.result;
+  }
+
+  @override
+  Future<SqlTextId> storeSql(SqlStreamId stream, String sql) async {
+    if (_isClosed) {
+      throw const ConnectionClosed();
+    }
+    final textId = SqlTextId(_nextSqlTextId++);
+    final response = await _runPipeline(
+      streamId: stream,
+      request: proto.StreamRequest(
+        storeSql: proto.StoreSqlReq(sql: sql, sqlId: textId.id),
+      ),
+    );
+    assert(response.whichResponse() == proto.StreamResponse_Response.storeSql);
+    return textId;
+  }
+
+  @override
+  Future<void> closeSql(SqlStreamId stream, SqlTextId id) async {
+    if (_isClosed) {
+      throw const ConnectionClosed();
+    }
+    final response = await _runPipeline(
+      streamId: stream,
+      request: proto.StreamRequest(
+        closeSql: proto.CloseSqlReq(sqlId: id.id),
+      ),
+    );
+    assert(response.whichResponse() == proto.StreamResponse_Response.closeSql);
+  }
+
+  var _isClosed = false;
+
+  @override
+  bool get isClosed => _isClosed;
+
+  @override
+  Future<void> get closed => _closed.future;
+
+  @override
+  Future<void> close() async {
+    if (_isClosed) {
+      return;
+    }
+    _isClosed = true;
+    _streams.clear();
+    _httpClient.close();
+    _closed.complete();
+  }
+}
+
+typedef _SqlStreamInfo = ({
+  String baton,
+  Uri? baseUri,
+});
+
+final class _AuthorizingHttpClient extends http.BaseClient {
+  _AuthorizingHttpClient({
+    http.Client? inner,
+    String? jwtToken,
+  })  : _ownsInner = inner == null,
+        _inner = inner ?? http.Client(),
+        _jwtToken = jwtToken;
+
+  final bool _ownsInner;
+  final http.Client _inner;
+  final String? _jwtToken;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    if (_jwtToken != null) {
+      request.headers['Authorization'] = 'Bearer $_jwtToken';
+    }
+    return _inner.send(request);
+  }
+
+  @override
+  void close() {
+    if (_ownsInner) {
+      _inner.close();
+    }
+  }
+}

--- a/hrana/lib/src/rpc_ws_client.dart
+++ b/hrana/lib/src/rpc_ws_client.dart
@@ -1,0 +1,162 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:stream_channel/stream_channel.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'exception.dart';
+import 'protocol.pb.dart' as proto;
+import 'rpc_client.dart';
+
+final class HranaWebsocketClient implements HranaClient {
+  final StreamChannel<dynamic> _channel;
+  bool _closed = false;
+  final Completer<void> _streamClosed = Completer();
+
+  Completer<void>? _helloCompleter;
+  final Map<int, Completer<proto.ResponseOkMsg>> _pendingRequests = {};
+  int _nextRequestId = 0;
+  int _nextStreamId = 0;
+  int _nextSqlTextId = 0;
+
+  HranaWebsocketClient._(this._channel) {
+    _channel.stream.listen((data) {
+      if (data is Uint8List) {
+        _handleMessage(data);
+      } else {
+        throw 'Unexpected message: $data';
+      }
+    }, onDone: _closedByRemote);
+  }
+
+  @override
+  bool get isClosed => _closed;
+
+  @override
+  Future<void> get closed => _streamClosed.future;
+
+  void _closedByRemote() {
+    _closed = true;
+    for (final pending in _pendingRequests.values) {
+      pending.completeError(const ConnectionClosed());
+    }
+    _streamClosed.complete();
+  }
+
+  @override
+  Future<void> close() async {
+    _closed = true;
+    if (_channel case WebSocketChannel ws) {
+      await ws.sink.close(1000, 'connection closed');
+    } else {
+      await _channel.sink.close();
+    }
+
+    await _streamClosed.future;
+  }
+
+  @override
+  Future<SqlStreamId> openStream() async {
+    final streamId = _nextStreamId++;
+    await _request(
+        proto.RequestMsg(openStream: proto.OpenStreamReq(streamId: streamId)));
+    return SqlStreamId(streamId);
+  }
+
+  @override
+  Future<void> closeStream(SqlStreamId id) async {
+    await _request(
+        proto.RequestMsg(closeStream: proto.CloseStreamReq(streamId: id.id)));
+  }
+
+  @override
+  Future<StatementResult> executeStatement(
+      SqlStreamId stream, StatementDescription stmt) async {
+    final response = await _request(proto.RequestMsg(
+      execute: proto.ExecuteReq(
+        streamId: stream.id,
+        stmt: stmt.toStatement(),
+      ),
+    ));
+
+    return StatementResult.fromProto(response.execute.result);
+  }
+
+  @override
+  Future<SqlTextId> storeSql(SqlStreamId stream, String sql) async {
+    final textId = _nextSqlTextId++;
+    await _request(
+        proto.RequestMsg(storeSql: proto.StoreSqlReq(sqlId: textId, sql: sql)));
+    return SqlTextId(textId);
+  }
+
+  @override
+  Future<void> closeSql(SqlStreamId stream, SqlTextId id) async {
+    await _request(proto.RequestMsg(closeSql: proto.CloseSqlReq(sqlId: id.id)));
+  }
+
+  @override
+  Future<proto.BatchResult> runBatch(
+      SqlStreamId stream, proto.Batch batch) async {
+    final response = await _request(proto.RequestMsg(
+        batch: proto.BatchReq(batch: batch, streamId: stream.id)));
+    return response.batch.result;
+  }
+
+  Future<void> _hello(String? jwt) async {
+    final completer = _helloCompleter = Completer();
+    _send(proto.ClientMsg(hello: proto.HelloMsg(jwt: jwt)));
+    await completer.future;
+    _helloCompleter = null;
+  }
+
+  Future<proto.ResponseOkMsg> _request(proto.RequestMsg request) async {
+    final id = _nextRequestId++;
+    final completer = Completer<proto.ResponseOkMsg>();
+    _pendingRequests[id] = completer;
+    _send(proto.ClientMsg(request: request..requestId = id));
+
+    return await completer.future;
+  }
+
+  void _send(proto.ClientMsg msg) {
+    if (_closed) {
+      throw const ConnectionClosed();
+    }
+
+    _channel.sink.add(msg.writeToBuffer());
+  }
+
+  void _handleMessage(Uint8List data) {
+    final msg = proto.ServerMsg.fromBuffer(data);
+
+    if (msg.hasHelloOk()) {
+      _helloCompleter?.complete();
+    } else if (msg.hasHelloError()) {
+      _helloCompleter?.completeError(
+        ServerException.fromProto(msg.helloError.error),
+      );
+    } else if (msg.hasResponseOk()) {
+      final id = msg.responseOk.requestId;
+      final completer = _pendingRequests.remove(id);
+      completer?.complete(msg.responseOk);
+    } else if (msg.hasResponseError()) {
+      final id = msg.responseError.requestId;
+      final completer = _pendingRequests.remove(id);
+      completer?.completeError(
+        ServerException.fromProto(msg.responseError.error),
+      );
+    }
+  }
+
+  static Future<HranaWebsocketClient> connect(Uri uri,
+      {String? jwtToken}) async {
+    final channel =
+        WebSocketChannel.connect(uri, protocols: ['hrana3-protobuf']);
+    await channel.ready;
+
+    final client = HranaWebsocketClient._(channel);
+    await client._hello(jwtToken);
+    return client;
+  }
+}

--- a/hrana/proto.sh
+++ b/hrana/proto.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/env bash
 
-protoc --dart_out=. lib/src/protocol.protoc
+protoc --dart_out=. lib/src/protocol.proto
 dart format lib/

--- a/hrana/pubspec.yaml
+++ b/hrana/pubspec.yaml
@@ -14,6 +14,7 @@ environment:
 
 dependencies:
   fixnum: ^1.1.0
+  http: ^1.0.0
   protobuf: ^3.1.0
   sqlite3: ^2.4.4
   stream_channel: ^2.1.2

--- a/hrana/test/hrana_test.dart
+++ b/hrana/test/hrana_test.dart
@@ -10,17 +10,17 @@ void main() {
 
   late Database database;
 
+  setUpAll(() async {
+    port = await selectFreePort();
+    server = await startSqld(port);
+  });
+
+  tearDownAll(() async {
+    await server.stop();
+  });
+
   for (final scheme in const ['http', 'ws']) {
     group(scheme, () {
-      setUpAll(() async {
-        port = await selectFreePort();
-        server = await startSqld(port);
-      });
-
-      tearDownAll(() async {
-        await server.stop();
-      });
-
       setUp(() async {
         database = await Database.connect(
           Uri.parse('$scheme://localhost:$port/'),
@@ -59,6 +59,7 @@ void main() {
               await database.storeSql('INSERT INTO users (name) VALUES (?);');
           final result = await stored.execute(arguments: ['Stored']);
           expect(result.affectedRows, 1);
+          expect(result.lastInsertRowId, 1);
         });
 
         test('can be selected', () async {

--- a/hrana/test/hrana_test.dart
+++ b/hrana/test/hrana_test.dart
@@ -10,107 +10,113 @@ void main() {
 
   late Database database;
 
-  setUpAll(() async {
-    port = await selectFreePort();
-    server = await startSqld(port);
-  });
-
-  tearDownAll(() async {
-    await server.stop();
-  });
-
-  setUp(() async {
-    database = await Database.connect(Uri.parse('ws://localhost:$port/'));
-
-    await database
-        .execute('CREATE TABLE users (name TEXT, CHECK (LENGTH(name) < 10));');
-  });
-
-  tearDown(() async {
-    await database.execute('DROP TABLE users;');
-
-    await database.close();
-  });
-
-  test('can select statements', () async {
-    final result = await database.select('SELECT 1 AS r;');
-    expect(result.columnNames, ['r']);
-    expect(result.rows, [
-      [1]
-    ]);
-  });
-
-  test('can execute statements', () async {
-    final result = await database.execute(
-      'INSERT INTO users (name) VALUES (?);',
-      arguments: ['name'],
-    );
-    expect(result.affectedRows, 1);
-    expect(result.lastInsertRowId, 1, skip: 'rowid appears to not be sent');
-  });
-
-  group('stored statements', () {
-    test('can be executed', () async {
-      final stored =
-          await database.storeSql('INSERT INTO users (name) VALUES (?);');
-      final result = await stored.execute(arguments: ['Stored']);
-      expect(result.affectedRows, 1);
-    });
-
-    test('can be selected', () async {
-      final stored = await database.storeSql('SELECT 1');
-      final result = await stored.select();
-      expect(result.rows, [
-        [1]
-      ]);
-    });
-
-    test("don't work after being closed", () async {
-      final stored = await database.storeSql('SELECT 1');
-      await stored.close();
-      expect(() => stored.execute(), throwsStateError);
-    });
-  });
-
-  group('batch', () {
-    test('can run statements', () async {
-      final storedSelect = await database.storeSql('SELECT * FROM users;');
-      final storedExecute =
-          await database.storeSql('INSERT INTO users (name) VALUES (?);');
-
-      final results = await database.batch((builder) {
-        builder
-          ..executeStored(storedExecute, arguments: ['first'])
-          ..select('SELECT * FROM users;')
-          ..execute('INSERT INTO users (name) VALUES (?)',
-              arguments: ['second'])
-          ..selectStored(storedSelect);
+  for (final scheme in const ['http', 'ws']) {
+    group(scheme, () {
+      setUpAll(() async {
+        port = await selectFreePort();
+        server = await startSqld(port);
       });
 
-      final firstSelect = results.selectResult(1 as BatchRequest);
-      final secondSelect = results.selectResult(3 as BatchRequest);
-
-      expect(firstSelect!.rows, [
-        ['first']
-      ]);
-      expect(secondSelect!.rows, [
-        ['first'],
-        ['second']
-      ]);
-    });
-
-    test('does not run statements after failure', () async {
-      final results = await database.batch((builder) {
-        builder
-          ..execute('INSERT INTO users (name) VALUES (?);', arguments: [
-            'very long name that will be rejected by the check constraint'
-          ])
-          ..execute('SELECT * FROM users;');
+      tearDownAll(() async {
+        await server.stop();
       });
 
-      expect(() => results.executeResult(0 as BatchRequest),
-          throwsA(isA<ServerException>()));
-      expect(results.selectResult(1 as BatchRequest), isNull);
+      setUp(() async {
+        database = await Database.connect(
+          Uri.parse('$scheme://localhost:$port/'),
+        );
+
+        await database.execute(
+            'CREATE TABLE users (name TEXT, CHECK (LENGTH(name) < 10));');
+      });
+
+      tearDown(() async {
+        await database.execute('DROP TABLE users;');
+
+        await database.close();
+      });
+
+      test('can select statements', () async {
+        final result = await database.select('SELECT 1 AS r;');
+        expect(result.columnNames, ['r']);
+        expect(result.rows, [
+          [1]
+        ]);
+      });
+
+      test('can execute statements', () async {
+        final result = await database.execute(
+          'INSERT INTO users (name) VALUES (?);',
+          arguments: ['name'],
+        );
+        expect(result.affectedRows, 1);
+        expect(result.lastInsertRowId, 1);
+      });
+
+      group('stored statements', () {
+        test('can be executed', () async {
+          final stored =
+              await database.storeSql('INSERT INTO users (name) VALUES (?);');
+          final result = await stored.execute(arguments: ['Stored']);
+          expect(result.affectedRows, 1);
+        });
+
+        test('can be selected', () async {
+          final stored = await database.storeSql('SELECT 1');
+          final result = await stored.select();
+          expect(result.rows, [
+            [1]
+          ]);
+        });
+
+        test("don't work after being closed", () async {
+          final stored = await database.storeSql('SELECT 1');
+          await stored.close();
+          expect(() => stored.execute(), throwsStateError);
+        });
+      });
+
+      group('batch', () {
+        test('can run statements', () async {
+          final storedSelect = await database.storeSql('SELECT * FROM users;');
+          final storedExecute =
+              await database.storeSql('INSERT INTO users (name) VALUES (?);');
+
+          final results = await database.batch((builder) {
+            builder
+              ..executeStored(storedExecute, arguments: ['first'])
+              ..select('SELECT * FROM users;')
+              ..execute('INSERT INTO users (name) VALUES (?)',
+                  arguments: ['second'])
+              ..selectStored(storedSelect);
+          });
+
+          final firstSelect = results.selectResult(1 as BatchRequest);
+          final secondSelect = results.selectResult(3 as BatchRequest);
+
+          expect(firstSelect!.rows, [
+            ['first']
+          ]);
+          expect(secondSelect!.rows, [
+            ['first'],
+            ['second']
+          ]);
+        });
+
+        test('does not run statements after failure', () async {
+          final results = await database.batch((builder) {
+            builder
+              ..execute('INSERT INTO users (name) VALUES (?);', arguments: [
+                'very long name that will be rejected by the check constraint'
+              ])
+              ..execute('SELECT * FROM users;');
+          });
+
+          expect(() => results.executeResult(0 as BatchRequest),
+              throwsA(isA<ServerException>()));
+          expect(results.selectResult(1 as BatchRequest), isNull);
+        });
+      });
     });
-  });
+  }
 }


### PR DESCRIPTION
Adds support for HTTP(S) connections using [Hrana over HTTP](https://github.com/tursodatabase/libsql/blob/main/docs/HRANA_3_SPEC.md#hrana-over-http). Most of the protobufs can be reused, but the HTTP variant does not include the stream ID in the body.

Includes minor clean up:
- Adds support for `libsql` scheme (common to other libsql clients)
- Remove expect skip and fix decoding of `StatementResult`
- Change protobuf file ext to `.proto` for IDE support
- Add `ServerException.fromProto` to remove dependence on the WS client