### PR TITLE
Expose streams as sessions

### DIFF
--- a/drift_hrana/CHANGELOG.md
+++ b/drift_hrana/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+- Support the latest version of `package:hrana`.
+
 ## 1.0.2
 
 - Support the latest version of `package:hrana`.

--- a/drift_hrana/lib/drift_hrana.dart
+++ b/drift_hrana/lib/drift_hrana.dart
@@ -6,6 +6,7 @@ library;
 import 'dart:async';
 
 import 'package:drift/backends.dart';
+import 'package:drift/drift.dart';
 import 'package:hrana/hrana.dart';
 
 final class HranaDatabase extends DelegatedDatabase {
@@ -15,36 +16,68 @@ final class HranaDatabase extends DelegatedDatabase {
       : this._(_HranaDelegate(uri: uri, jwtToken: jwtToken));
 }
 
-final class _HranaDelegate extends DatabaseDelegate {
+abstract class _BaseHranaDelegate extends QueryDelegate {
+  Future<T> _run<T>(Future<T> Function(DatabaseSession session) inner);
+
+  @override
+  Future<void> runCustom(String statement, List<Object?> args) async {
+    await _run((s) async => s.execute(statement, arguments: args));
+  }
+
+  @override
+  Future<int> runInsert(String statement, List<Object?> args) async {
+    final res = await _run((s) async => s.execute(statement, arguments: args));
+    return res.lastInsertRowId ?? 0;
+  }
+
+  @override
+  Future<QueryResult> runSelect(String statement, List<Object?> args) async {
+    final res = await _run((s) async => s.select(statement, arguments: args));
+    return QueryResult(res.columnNames, res.rows);
+  }
+
+  @override
+  Future<int> runUpdate(String statement, List<Object?> args) async {
+    final res = await _run((s) async => s.execute(statement, arguments: args));
+    return res.affectedRows;
+  }
+
+  @override
+  Future<void> runBatched(BatchedStatements statements) async {
+    await _run((s) async {
+      final prepared = <StoredSql>[];
+
+      for (final statement in statements.statements) {
+        final stored = await s.storeSql(statement);
+        prepared.add(stored);
+      }
+
+      await s.batch((b) {
+        for (final arg in statements.arguments) {
+          b.executeStored(prepared[arg.statementIndex],
+              arguments: arg.arguments);
+        }
+      });
+    });
+  }
+}
+
+final class _HranaDelegate extends _BaseHranaDelegate
+    implements DatabaseDelegate {
   Database? _database;
   var _isClosed = false;
 
   final Uri uri;
   final String? jwtToken;
 
+  @override
+  bool isInTransaction = false;
+
   _HranaDelegate({required this.uri, required this.jwtToken});
 
   @override
-  Future<void> runCustom(String statement, List<Object?> args) async {
-    await _database!.execute(statement, arguments: args);
-  }
-
-  @override
-  Future<int> runInsert(String statement, List<Object?> args) async {
-    final res = await _database!.execute(statement, arguments: args);
-    return res.lastInsertRowId ?? 0;
-  }
-
-  @override
-  Future<QueryResult> runSelect(String statement, List<Object?> args) async {
-    final res = await _database!.select(statement, arguments: args);
-    return QueryResult(res.columnNames, res.rows);
-  }
-
-  @override
-  Future<int> runUpdate(String statement, List<Object?> args) async {
-    final res = await _database!.execute(statement, arguments: args);
-    return res.affectedRows;
+  Future<T> _run<T>(Future<T> Function(DatabaseSession session) inner) async {
+    return _database!.withSession(inner);
   }
 
   @override
@@ -64,11 +97,55 @@ final class _HranaDelegate extends DatabaseDelegate {
   }
 
   @override
-  TransactionDelegate get transactionDelegate => const NoTransactionDelegate();
+  void notifyDatabaseOpened(OpeningDetails details) {}
+
+  @override
+  Future<void> close() async {
+    await _database?.close();
+  }
+
+  @override
+  late final TransactionDelegate transactionDelegate =
+      _HranaTransactionDelegate(this);
 
   @override
   DbVersionDelegate get versionDelegate =>
       _HranaVersionDelegate(delegate: this);
+}
+
+final class _HranaTransactionDelegate extends SupportedTransactionDelegate {
+  final _HranaDelegate _delegate;
+
+  _HranaTransactionDelegate(this._delegate);
+
+  @override
+  bool get managesLockInternally => true;
+
+  @override
+  FutureOr<void> startTransaction(
+      Future<void> Function(QueryDelegate) run) async {
+    await _delegate._run((s) async {
+      await s.execute('BEGIN');
+      try {
+        run(_HranaTransaction(s));
+        await s.execute('COMMIT');
+      } catch (e) {
+        await s.execute('ROLLBACK');
+        rethrow;
+      }
+    });
+  }
+}
+
+final class _HranaTransaction extends _BaseHranaDelegate {
+  final DatabaseSession _session;
+
+  _HranaTransaction(this._session);
+
+  @override
+  Future<T> _run<T>(Future<T> Function(DatabaseSession session) inner) async {
+    return await inner(_session);
+  }
 }
 
 final class _HranaVersionDelegate extends DynamicVersionDelegate {
@@ -78,12 +155,14 @@ final class _HranaVersionDelegate extends DynamicVersionDelegate {
 
   @override
   Future<int> get schemaVersion async {
-    final result = await delegate._database!.select('pragma user_version;');
+    final result = await delegate
+        ._run((s) async => await s.select('pragma user_version;'));
     return result.rows.first.first as int;
   }
 
   @override
   Future<void> setSchemaVersion(int version) async {
-    await delegate._database!.execute('pragma user_version = $version;');
+    await delegate
+        ._run((s) async => s.execute('pragma user_version = $version;'));
   }
 }

--- a/drift_hrana/pubspec.yaml
+++ b/drift_hrana/pubspec.yaml
@@ -1,6 +1,6 @@
 name: drift_hrana
 description: Use a remote libsql server with your drift database.
-version: 1.0.2
+version: 1.0.3
 repository: https://github.com/simolus3/hrana.dart
 topics:
   - database

--- a/drift_hrana/test/http_timeout_test.dart
+++ b/drift_hrana/test/http_timeout_test.dart
@@ -1,0 +1,36 @@
+import 'package:docker_process/docker_process.dart';
+import 'package:drift_hrana/drift_hrana.dart';
+import 'package:test/test.dart';
+
+import '../example/main.dart';
+import 'start_server.dart';
+
+void main() {
+  late int port;
+  late DockerProcess server;
+
+  setUpAll(() async {
+    port = await selectFreePort();
+    server = await startSqld(port);
+  });
+
+  tearDownAll(() async {
+    await server.stop();
+  });
+
+  late AppDatabase database;
+
+  setUp(() {
+    database = AppDatabase(HranaDatabase(Uri.parse('http://localhost:$port/')));
+  });
+  tearDown(() async {
+    await database.close();
+  });
+
+  test('can keep using database after 15 seconds', () async {
+    // See https://github.com/tursodatabase/libsql/issues/985
+    await database.customSelect('SELECT 1').get();
+    await Future<void>.delayed(const Duration(seconds: 15));
+    await database.customSelect('SELECT 1').get();
+  });
+}

--- a/hrana/CHANGELOG.md
+++ b/hrana/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.0
+
+- __Breaking__: Move operations into `DatabaseSession` class obtained through
+  `Database.withSession`.
+  By no longer using long-lived sessions, the client avoids timeouts when
+  keeping a database open for a long time.
+
 ## 0.3.0
 
 - Support the HTTP protocol for hrana databases.

--- a/hrana/README.md
+++ b/hrana/README.md
@@ -25,13 +25,18 @@ void main() async {
     Uri.parse('ws://localhost:8080/'),
     jwtToken: null,
   );
-  print(await database.select('SELECT 1;'));
+  print(await database.withSession((session) async {
+    await session.select('SELECT 1;');
+  }));
 }
 ```
 
+In addition to web sockets, an HTTP client is available as well and selected
+automatically when using an `http://` or `https://` URL.
+
 ## Additional information
 
-At the moment, this package implementats functionality to execute statements
+At the moment, this package implements functionality to execute statements
 and getting their results as rows.
 Batches and stored statements are supported as well, but no support for
 streaming cursors is implemented yet.

--- a/hrana/example/hrana_example.dart
+++ b/hrana/example/hrana_example.dart
@@ -9,5 +9,8 @@ void main() async {
   );
   print('connected!');
 
-  print(await database.select('SELECT 1;'));
+  print(await database
+      .withSession((session) async => await session.select('SELECT 1;')));
+
+  await database.close();
 }

--- a/hrana/lib/src/protocol.proto
+++ b/hrana/lib/src/protocol.proto
@@ -1,4 +1,4 @@
-// Adapted from: 
+// Adapted from:
 // - https://github.com/tursodatabase/libsql/blob/main/docs/HRANA_3_SPEC.md
 // - https://github.com/tursodatabase/libsql/blob/main/libsql-hrana/src/proto.rs
 

--- a/hrana/lib/src/rpc_client.dart
+++ b/hrana/lib/src/rpc_client.dart
@@ -1,21 +1,30 @@
+@internal
+library;
+
 import 'package:fixnum/fixnum.dart';
+import 'package:meta/meta.dart';
 
 import 'protocol.pb.dart' as proto;
 
 abstract interface class HranaClient {
-  Future<SqlStreamId> openStream();
-  Future<void> closeStream(SqlStreamId id);
-  Future<StatementResult> executeStatement(
-      SqlStreamId stream, StatementDescription stmt);
-  Future<SqlTextId> storeSql(SqlStreamId stream, String sql);
-  Future<void> closeSql(SqlStreamId stream, SqlTextId id);
-  Future<proto.BatchResult> runBatch(SqlStreamId stream, proto.Batch batch);
+  Future<HranaStream> openStream();
   Future<void> close();
-  bool get isClosed;
+
   Future<void> get closed;
+  bool get isClosed;
 }
 
-extension type SqlStreamId(int id) {}
+abstract interface class HranaStream {
+  Future<bool> checkOpen();
+
+  Future<StatementResult> executeStatement(StatementDescription stmt);
+  Future<SqlTextId> storeSql(String sql);
+  Future<void> closeSql(SqlTextId id);
+  Future<proto.BatchResult> runBatch(proto.Batch batch);
+  Future<void> closeStream();
+
+  Future<void> get closed;
+}
 
 extension type SqlTextId(int id) {}
 

--- a/hrana/pubspec.yaml
+++ b/hrana/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hrana
 description: Dart client for hrana, a protocol for accessing libsql database servers.
-version: 0.3.0
+version: 0.4.0-dev
 repository: https://github.com/simolus3/hrana.dart
 topics:
   - database
@@ -13,8 +13,11 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
+  clock: ^1.1.2
   fixnum: ^1.1.0
   http: ^1.0.0
+  meta: ^1.16.0
+  pool: ^1.5.1
   protobuf: ^3.1.0
   sqlite3: ^2.4.4
   stream_channel: ^2.1.2


### PR DESCRIPTION
This refactors the `hrana` package and its public API so that we no longer keep hrana streams open during the entire lifetime of the database. Instead, streams are requested from the database for every operation and are considered to be short-lived.

This works much better for the libsql HTTP server, which expires streams after they are unused for 10 seconds. CC @dnys1, since you've added the HTTP client: Did you run into these issues as well or are you using short-lived database connections? Do you think these changes would negatively affect your usages (essentially the migration is to keep the `Database` instance around for longer and then call `withSession` to obtain a short-lived session instance to issue statements).

Closes https://github.com/simolus3/hrana.dart/issues/5.
