### PR TITLE
Migrate `drift_hrana` away from `pragma user_version`

### DIFF
--- a/drift_hrana/CHANGELOG.md
+++ b/drift_hrana/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+## 1.0.5
+
+- Stop using `user_version` pragma for migration, improving support with Turso.
+
 ## 1.0.4
 
 - Fix transactions not working.

--- a/drift_hrana/lib/drift_hrana.dart
+++ b/drift_hrana/lib/drift_hrana.dart
@@ -151,6 +151,12 @@ final class _HranaTransaction extends _BaseHranaDelegate {
   }
 }
 
+/// A [DbVersionDelegate] implementation for hrana databases backed by a table
+/// storing the current version in the database.
+///
+/// While drift would use the `user_version` pragma for regular SQLite
+/// databases, some hrana servers (most notably Turso's cloud offering) don't
+/// support that.
 final class _HranaVersionDelegate extends DynamicVersionDelegate {
   final _HranaDelegate delegate;
 

--- a/drift_hrana/pubspec.yaml
+++ b/drift_hrana/pubspec.yaml
@@ -20,5 +20,6 @@ dev_dependencies:
   build_runner: ^2.4.11
   docker_process: ^1.3.1
   drift_dev: ^2.21.0
+  http: ^1.3.0
   lints: ^3.0.0
   test: ^1.24.0

--- a/drift_hrana/pubspec.yaml
+++ b/drift_hrana/pubspec.yaml
@@ -1,6 +1,6 @@
 name: drift_hrana
 description: Use a remote libsql server with your drift database.
-version: 1.0.4
+version: 1.0.5
 repository: https://github.com/simolus3/hrana.dart
 topics:
   - database
@@ -13,7 +13,7 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
-  drift: ^2.22.1
+  drift: ^2.26.1
   hrana: ^0.4.0
 
 dev_dependencies:

--- a/drift_hrana/test/drift_hrana_test.dart
+++ b/drift_hrana/test/drift_hrana_test.dart
@@ -1,101 +1,100 @@
 import 'dart:async';
 
-import 'package:docker_process/docker_process.dart';
 import 'package:drift/drift.dart';
 import 'package:drift_hrana/drift_hrana.dart';
 import 'package:test/test.dart';
 
 import '../example/main.dart';
-import 'start_server.dart';
+import 'target_server.dart';
 
 void main() {
-  late int port;
-  late DockerProcess server;
-
-  setUpAll(() async {
-    port = await selectFreePort();
-    server = await startSqld(port);
-  });
-
-  tearDownAll(() async {
-    await server.stop();
-  });
-
   late AppDatabase database;
 
-  setUp(() {
-    database = AppDatabase(HranaDatabase(Uri.parse('http://localhost:$port/')));
-  });
-  tearDown(() async {
-    await database.close();
-  });
+  for (final server in targetServers) {
+    group(server.name, () {
+      setUp(() {
+        database = AppDatabase(
+          HranaDatabase(
+            server.uri(),
+            jwtToken: server.authToken(),
+          ),
+        );
+      });
 
-  test('reports dialect as sqlite', () async {
-    expect(database.executor.dialect, SqlDialect.sqlite);
-  });
+      tearDown(() async {
+        await database.close();
+      });
 
-  test('statements', () async {
-    final note = await database.notes
-        .insertReturning(NotesCompanion.insert(content: 'my first todo note'));
-    expect(note.content, 'my first todo note');
+      test('reports dialect as sqlite', () async {
+        expect(database.executor.dialect, SqlDialect.sqlite);
+      });
 
-    final all = await database.notes.all().get();
-    expect(all, contains(note));
-  });
+      test('statements', () async {
+        final note = await database.notes.insertReturning(
+            NotesCompanion.insert(content: 'my first todo note'));
+        expect(note.content, 'my first todo note');
 
-  test('transactions', () async {
-    await database.notes
-        .insertOne(NotesCompanion.insert(content: 'about to be deleted'));
-    await database.transaction(() async {
-      await database.notes.delete().go();
-    });
+        final all = await database.notes.all().get();
+        expect(all, contains(note));
+      });
 
-    expect(await database.notes.all().get(), isEmpty);
-  });
+      test('transactions', () async {
+        await database.notes
+            .insertOne(NotesCompanion.insert(content: 'about to be deleted'));
+        await database.transaction(() async {
+          await database.notes.delete().go();
+        });
 
-  test('concurrent transactions and top-level statemens', () async {
-    await database.notes
-        .insertOne(NotesCompanion.insert(content: 'about to be deleted'));
-    final completeTransaction = Completer<void>();
+        expect(await database.notes.all().get(), isEmpty);
+      });
 
-    final transactionDone = database.transaction(() async {
-      await database.notes.delete().go();
-      await completeTransaction.future;
-    });
+      test('concurrent transactions and top-level statemens', () async {
+        await database.notes
+            .insertOne(NotesCompanion.insert(content: 'about to be deleted'));
+        final completeTransaction = Completer<void>();
 
-    expect(await database.notes.all().get(), isNotEmpty);
-    completeTransaction.complete();
-    await transactionDone;
-    expect(await database.notes.all().get(), isEmpty);
-  });
+        final transactionDone = database.transaction(() async {
+          await database.notes.delete().go();
+          await completeTransaction.future;
+        });
 
-  test('supports table migrations', () async {
-    // Regression test for https://github.com/simolus3/drift/issues/3088
+        expect(await database.notes.all().get(), isNotEmpty);
+        completeTransaction.complete();
+        await transactionDone;
+        expect(await database.notes.all().get(), isEmpty);
+      });
 
-    await database.notes
-        .insertOne(NotesCompanion.insert(content: 'existing content'));
+      test('supports table migrations', () async {
+        // Regression test for https://github.com/simolus3/drift/issues/3088
 
-    // create unrelated table and view
-    await database.customStatement('''
+        await database.notes
+            .insertOne(NotesCompanion.insert(content: 'existing content'));
+
+        // create unrelated table and view
+        await database.customStatement('''
 CREATE TABLE unrelated (
   id INTEGER NOT NULL PRIMARY KEY,
   content TEXT
 );
 ''');
-    await database.customInsert('INSERT INTO unrelated (content) VALUES (?)',
-        variables: [Variable.withString('foo')]);
-    await database.customStatement(
-        'CREATE VIEW unrelated_view AS SELECT * FROM unrelated;');
+        await database.customInsert(
+            'INSERT INTO unrelated (content) VALUES (?)',
+            variables: [Variable.withString('foo')]);
+        await database.customStatement(
+            'CREATE VIEW unrelated_view AS SELECT * FROM unrelated;');
 
-    // Issue table migration. Drift normally tries to enable the legacy alter
-    // table behavior for this, which is disabled with Turso.
-    await Migrator(database).alterTable(TableMigration(database.notes));
+        // Issue table migration. Drift normally tries to enable the legacy alter
+        // table behavior for this, which is disabled with Turso.
+        await Migrator(database).alterTable(TableMigration(database.notes));
 
-    // Table should still be there
-    expect(await database.notes.all().get(), hasLength(1));
+        // Table should still be there
+        expect(await database.notes.all().get(), hasLength(1));
 
-    // And the unrelated table with data should also work.
-    expect(await database.customSelect('SELECT * FROM unrelated_view').get(),
-        hasLength(1));
-  });
+        // And the unrelated table with data should also work.
+        expect(
+            await database.customSelect('SELECT * FROM unrelated_view').get(),
+            hasLength(1));
+      });
+    });
+  }
 }

--- a/drift_hrana/test/drift_hrana_test.dart
+++ b/drift_hrana/test/drift_hrana_test.dart
@@ -10,8 +10,10 @@ import 'target_server.dart';
 void main() {
   late AppDatabase database;
 
-  for (final server in targetServers) {
-    group(server.name, () {
+  for (final (name, target) in targetServers) {
+    group(name, skip: target == null ? 'Not available' : null, () {
+      late final server = target!;
+
       setUp(() {
         database = AppDatabase(
           HranaDatabase(

--- a/drift_hrana/test/http_timeout_test.dart
+++ b/drift_hrana/test/http_timeout_test.dart
@@ -6,8 +6,11 @@ import 'target_server.dart';
 
 void main() {
   late AppDatabase database;
-  for (final server in targetServers) {
-    group(server.name, () {
+
+  for (final (name, target) in targetServers) {
+    group(name, skip: target == null ? 'Not available' : null, () {
+      late final server = target!;
+
       setUp(() {
         database = AppDatabase(
           HranaDatabase(server.uri(), jwtToken: server.authToken()),

--- a/drift_hrana/test/http_timeout_test.dart
+++ b/drift_hrana/test/http_timeout_test.dart
@@ -1,36 +1,28 @@
-import 'package:docker_process/docker_process.dart';
 import 'package:drift_hrana/drift_hrana.dart';
 import 'package:test/test.dart';
 
 import '../example/main.dart';
-import 'start_server.dart';
+import 'target_server.dart';
 
 void main() {
-  late int port;
-  late DockerProcess server;
-
-  setUpAll(() async {
-    port = await selectFreePort();
-    server = await startSqld(port);
-  });
-
-  tearDownAll(() async {
-    await server.stop();
-  });
-
   late AppDatabase database;
+  for (final server in targetServers) {
+    group(server.name, () {
+      setUp(() {
+        database = AppDatabase(
+          HranaDatabase(server.uri(), jwtToken: server.authToken()),
+        );
+      });
+      tearDown(() async {
+        await database.close();
+      });
 
-  setUp(() {
-    database = AppDatabase(HranaDatabase(Uri.parse('http://localhost:$port/')));
-  });
-  tearDown(() async {
-    await database.close();
-  });
-
-  test('can keep using database after 15 seconds', () async {
-    // See https://github.com/tursodatabase/libsql/issues/985
-    await database.customSelect('SELECT 1').get();
-    await Future<void>.delayed(const Duration(seconds: 15));
-    await database.customSelect('SELECT 1').get();
-  });
+      test('can keep using database after 15 seconds', () async {
+        // See https://github.com/tursodatabase/libsql/issues/985
+        await database.customSelect('SELECT 1').get();
+        await Future<void>.delayed(const Duration(seconds: 15));
+        await database.customSelect('SELECT 1').get();
+      });
+    });
+  }
 }

--- a/drift_hrana/test/migration_test.dart
+++ b/drift_hrana/test/migration_test.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:drift_hrana/drift_hrana.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+import '../example/main.dart';
+import 'target_server.dart';
+
+void main() {
+  final server = withLocalServer();
+
+  test('migrates without pragma user_version', () async {
+    final database = _TestMigrationDatabase(
+      HranaDatabase(server.uri(), jwtToken: server.authToken()),
+      migration: MigrationStrategy(
+        onCreate: expectAsync1((m) async {
+          await m.createAll();
+        }),
+      ),
+    );
+    addTearDown(database.close);
+
+    final version = await database
+        .customSelect('SELECT user_version FROM __drift_user_version')
+        .getSingle();
+    expect(version.read<int>('user_version'), 1);
+  });
+
+  test('migrates with pragma user_version', () async {
+    final result = await http.post(
+      server.uri().replace(path: '/v3/pipeline'),
+      body: jsonEncode({
+        "requests": [
+          {
+            "type": "execute",
+            "stmt": {"sql": "pragma user_version = 1;"}
+          },
+          {"type": "close"}
+        ]
+      }),
+    );
+    expect(result.statusCode, 200, reason: result.body);
+
+    final database = _TestMigrationDatabase(
+      HranaDatabase(server.uri(), jwtToken: server.authToken()),
+      migration: MigrationStrategy(
+        onUpgrade: expectAsync3((m, from, to) async {
+          expect(from, 1);
+          expect(to, 2);
+        }),
+      ),
+      schemaVersion: 2,
+    );
+    addTearDown(database.close);
+
+    final version = await database
+        .customSelect('SELECT user_version FROM __drift_user_version')
+        .getSingle();
+    expect(version.read<int>('user_version'), 2);
+  });
+}
+
+final class _TestMigrationDatabase extends AppDatabase {
+  _TestMigrationDatabase(
+    super.e, {
+    required this.migration,
+    this.schemaVersion = 1,
+  });
+
+  @override
+  final MigrationStrategy migration;
+
+  @override
+  final int schemaVersion;
+}

--- a/drift_hrana/test/target_server.dart
+++ b/drift_hrana/test/target_server.dart
@@ -6,18 +6,16 @@ import 'package:test/test.dart';
 
 import 'start_server.dart';
 
-typedef TargetServer = ({
-  String name,
-  Uri Function() uri,
-  String? Function() authToken
-});
+typedef TargetServer = ({Uri Function() uri, String? Function() authToken});
 
 /// The list of target servers to run the test suite against.
-List<TargetServer> get targetServers => [
-      withLocalServer(),
+List<(String name, TargetServer?)> get targetServers => [
+      ('localhost', withLocalServer()),
       if (Platform.environment['TURSO_API_TOKEN'] case final token?
           when token.isNotEmpty)
-        withTursoServer(),
+        ('turso cloud', withTursoServer())
+      else
+        ('turso cloud', null),
     ];
 
 TargetServer withLocalServer() {
@@ -34,7 +32,6 @@ TargetServer withLocalServer() {
   });
 
   return (
-    name: 'localhost',
     uri: () => Uri.parse('http://localhost:$port/'),
     authToken: () => null,
   );
@@ -67,7 +64,6 @@ TargetServer withTursoServer() {
   });
 
   return (
-    name: 'turso',
     uri: () => Uri.parse(databaseUrl),
     authToken: () => authToken,
   );

--- a/drift_hrana/test/target_server.dart
+++ b/drift_hrana/test/target_server.dart
@@ -1,0 +1,89 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:docker_process/docker_process.dart';
+import 'package:test/test.dart';
+
+import 'start_server.dart';
+
+typedef TargetServer = ({
+  String name,
+  Uri Function() uri,
+  String? Function() authToken
+});
+
+/// The list of target servers to run the test suite against.
+List<TargetServer> get targetServers => [
+      withLocalServer(),
+      if (Platform.environment['TURSO_API_TOKEN'] case final token?
+          when token.isNotEmpty)
+        withTursoServer(),
+    ];
+
+TargetServer withLocalServer() {
+  late int port;
+  late DockerProcess server;
+
+  setUpAll(() async {
+    port = await selectFreePort();
+    server = await startSqld(port);
+  });
+
+  tearDownAll(() async {
+    await server.stop();
+  });
+
+  return (
+    name: 'localhost',
+    uri: () => Uri.parse('http://localhost:$port/'),
+    authToken: () => null,
+  );
+}
+
+TargetServer withTursoServer() {
+  late String databaseName;
+  late String databaseUrl;
+  late String authToken;
+
+  setUpAll(() async {
+    databaseName = 'drift-hrana-test-${DateTime.now().millisecondsSinceEpoch}';
+    await _runProcess('turso', ['db', 'create', databaseName]);
+    databaseUrl = await _runProcess('turso', [
+      'db',
+      'show',
+      databaseName,
+      '--http-url',
+    ]);
+    authToken = await _runProcess('turso', [
+      'db',
+      'tokens',
+      'create',
+      databaseName,
+    ]);
+  });
+
+  tearDownAll(() async {
+    await _runProcess('turso', ['db', 'destroy', '--yes', databaseName]);
+  });
+
+  return (
+    name: 'turso',
+    uri: () => Uri.parse(databaseUrl),
+    authToken: () => authToken,
+  );
+}
+
+Future<String> _runProcess(String command, List<String> args) async {
+  final process = await Process.run(
+    command,
+    args,
+    stdoutEncoding: utf8,
+    stderrEncoding: utf8,
+    includeParentEnvironment: true,
+  );
+  if (process.exitCode != 0) {
+    throw Exception(
+        'Failed to run $command ${args.join(' ')}: ${process.stderr}');
+  }
+  return (process.stdout as String).trim();
+}


### PR DESCRIPTION
Depends on #8

Migrates `package:drift_hrana` away from using `pragma user_version` (which is no longer available in Turso) to maintaining a new `__drift_user_version` table following the example in [drift_postgres](https://github.com/simolus3/drift/blob/64885f63e8f98d56487c23278c382aca8e31f26e/extras/drift_postgres/lib/src/pg_database.dart#L190) and discussion [here](https://github.com/simolus3/hrana.dart/pull/8#issuecomment-28458458890).

Adds tests for both Turso and local Libsql that `pragma user_version` is no longer relied on and that databases previously using `pragma user_version` have their user version maintained across this update.