### PR TITLE
fix: Pool requests to prevent rate limiting by server

### DIFF
--- a/hrana/CHANGELOG.md
+++ b/hrana/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+
+- Pool requests to prevent rate limiting by server.
+
 ## 0.4.1
 
 - Migrates to JSON protocol

--- a/hrana/pubspec.yaml
+++ b/hrana/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hrana
 description: Dart client for hrana, a protocol for accessing libsql database servers.
-version: 0.4.1
+version: 0.4.2
 repository: https://github.com/simolus3/hrana.dart
 topics:
   - database


### PR DESCRIPTION
SQLd has an in-built [max_concurrent_requests](https://github.com/tursodatabase/libsql/blob/cdf90607d4da05a09920173a880e9ef021c5dfd3/libsql-server/src/main.rs#L247) limit which appears to be set in Turso as well. Sending requests past this limit will throw an error of "Too many concurrent requests".

This prevents the error from occurring by pooling requests in both the WS and HTTP clients. An alternative approach would be to catch this error and retry but this seems cleaner.