### PR TITLE
Fix CI concurrency issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,6 @@ jobs:
 
       - name: "Run tests"
         working-directory: ${{ matrix.package }}
-        run: dart test
+        run: dart test -j1
         env:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}

--- a/hrana/lib/src/exception.dart
+++ b/hrana/lib/src/exception.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import 'protocol.json.dart' as json;
 
 /// Superclass for all exceptions thrown by `package:hrana`.
@@ -15,6 +17,7 @@ final class ConnectionClosed implements HranaException {
 
 /// An exception thrown when the libsql server reports an error response for
 /// a request.
+@immutable
 final class ServerException implements HranaException {
   /// The error message reported from the server.
   final String message;
@@ -32,4 +35,14 @@ final class ServerException implements HranaException {
   String toString() {
     return 'HranaException($code): $message';
   }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ServerException &&
+        other.message == message &&
+        other.code == code;
+  }
+
+  @override
+  int get hashCode => Object.hash(message, code);
 }

--- a/hrana/lib/src/rpc_http_client.dart
+++ b/hrana/lib/src/rpc_http_client.dart
@@ -173,10 +173,17 @@ final class _HranaHttpStream implements HranaStream {
       body: _codec.encode(pipelineReq.toJson()),
     );
     if (pipelineResp.statusCode case < 200 || >= 300) {
-      throw ServerException(
-        message: 'Failed to run pipeline: "${pipelineResp.body}"',
-        code: pipelineResp.statusCode.toString(),
-      );
+      try {
+        final jsonResponse = json.StreamError.fromJson(
+          jsonDecode(pipelineResp.body) as Map<String, Object?>,
+        );
+        throw ServerException.fromJson(jsonResponse);
+      } on FormatException {
+        throw ServerException(
+          message: pipelineResp.body,
+          code: pipelineResp.statusCode.toString(),
+        );
+      }
     }
     final response = json.PipelineResp.fromJson(
       _codec.decode(pipelineResp.bodyBytes) as Map<String, Object?>,

--- a/hrana/lib/src/rpc_http_client.dart
+++ b/hrana/lib/src/rpc_http_client.dart
@@ -175,7 +175,7 @@ final class _HranaHttpStream implements HranaStream {
     if (pipelineResp.statusCode case < 200 || >= 300) {
       try {
         final jsonResponse = json.StreamError.fromJson(
-          jsonDecode(pipelineResp.body) as Map<String, Object?>,
+          _codec.decode(pipelineResp.bodyBytes) as Map<String, Object?>,
         );
         throw ServerException.fromJson(jsonResponse);
       } on FormatException {


### PR DESCRIPTION
As you mentioned, having multiple clients open will nullify the pooling work. In CI, we can limit the test concurrency to work around this.

In the HTTP client, we can better deserialize the server exceptions so that these exceptions are raised in a way they can be caught and matched better.